### PR TITLE
Progress before claude asked if it should continue.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,7 @@ fastlane/test_output
 
 iOSInjectionProject/
 /.swiftpm
+/.DS_Store
+/Tests/.DS_Store
+/Tests/MacroToolboxTests/.DS_Store
+/Tests/MacroToolboxTests/Introspection/.DS_Store

--- a/Sources/MacroToolbox/Diagnostics/AbstractSourceLocationStrategy.swift
+++ b/Sources/MacroToolbox/Diagnostics/AbstractSourceLocationStrategy.swift
@@ -2,15 +2,29 @@ import SwiftSyntax
 import SwiftDiagnostics
 import SwiftSyntaxMacros
 
+/// A strategy for determining source locations in diagnostic messages.
+///
+/// This struct provides configuration for how source locations should be determined
+/// when generating diagnostic messages, including positioning within syntax nodes
+/// and file path representation.
 public struct AbstractSourceLocationStrategy: @unchecked Sendable {
+  /// Specifies where in a syntax node the diagnostic position should be located.
   public let positionInSyntaxNode: PositionInSyntaxNode
+  
+  /// Specifies how file paths should be represented in source locations.
   public let filePathMode: SourceLocationFilePathMode
   
+  /// Creates a new source location strategy with the specified configuration.
+  ///
+  /// - Parameters:
+  ///   - positionInSyntaxNode: Where in a syntax node the diagnostic position should be located
+  ///   - filePathMode: How file paths should be represented in source locations
   public init(positionInSyntaxNode: PositionInSyntaxNode, filePathMode: SourceLocationFilePathMode) {
     self.positionInSyntaxNode = positionInSyntaxNode
     self.filePathMode = filePathMode
   }
   
+  /// A standard source location strategy that positions diagnostics after leading trivia and uses file paths.
   public static let standard = Self(
     positionInSyntaxNode: .afterLeadingTrivia,
     filePathMode: .filePath

--- a/Sources/MacroToolbox/Diagnostics/HDXLMacroDiagnostic.swift
+++ b/Sources/MacroToolbox/Diagnostics/HDXLMacroDiagnostic.swift
@@ -1,11 +1,26 @@
 import SwiftDiagnostics
 
+/// A structured diagnostic message for use in macro expansions.
+///
+/// This struct encapsulates diagnostic information including the message text,
+/// severity level, and a unique message identifier.
 public struct HDXLMacroDiagnostic : DiagnosticMessage {
   
+  /// The diagnostic message text to display to the user.
   public let message: String
+  
+  /// The severity level of the diagnostic.
   public let severity: DiagnosticSeverity
+  
+  /// A unique identifier for this type of diagnostic message.
   public let diagnosticID: MessageID
   
+  /// Creates a new macro diagnostic with the specified properties.
+  ///
+  /// - Parameters:
+  ///   - message: The diagnostic message text
+  ///   - severity: The severity level of the diagnostic
+  ///   - diagnosticID: A unique identifier for this type of diagnostic
   @inlinable
   public init(
     message: String,
@@ -50,6 +65,12 @@ extension HDXLMacroDiagnostic : CustomDebugStringConvertible {
 
 extension HDXLMacroDiagnostic {
 
+  /// Creates an error-level diagnostic message.
+  ///
+  /// - Parameters:
+  ///   - message: The diagnostic message text
+  ///   - diagnosticID: A unique identifier for this type of diagnostic
+  /// - Returns: A new diagnostic with error severity
   @inlinable
   public static func error(
     _ message: String,
@@ -62,6 +83,12 @@ extension HDXLMacroDiagnostic {
     )
   }
   
+  /// Creates a warning-level diagnostic message.
+  ///
+  /// - Parameters:
+  ///   - message: The diagnostic message text
+  ///   - diagnosticID: A unique identifier for this type of diagnostic
+  /// - Returns: A new diagnostic with warning severity
   @inlinable
   public static func warning(
     _ message: String,
@@ -74,6 +101,12 @@ extension HDXLMacroDiagnostic {
     )
   }
   
+  /// Creates a note-level diagnostic message.
+  ///
+  /// - Parameters:
+  ///   - message: The diagnostic message text
+  ///   - diagnosticID: A unique identifier for this type of diagnostic
+  /// - Returns: A new diagnostic with note severity
   @inlinable
   public static func note(
     _ message: String,
@@ -86,6 +119,12 @@ extension HDXLMacroDiagnostic {
     )
   }
   
+  /// Creates a remark-level diagnostic message.
+  ///
+  /// - Parameters:
+  ///   - message: The diagnostic message text
+  ///   - diagnosticID: A unique identifier for this type of diagnostic
+  /// - Returns: A new diagnostic with remark severity
   @inlinable
   public static func remark(
     _ message: String,

--- a/Sources/MacroToolbox/Generation/Support/Autoformatting.swift
+++ b/Sources/MacroToolbox/Generation/Support/Autoformatting.swift
@@ -2,6 +2,22 @@ import SwiftSyntax
 import SwiftSyntaxMacros
 import SwiftBasicFormat
 
+/// Executes a closure and automatically reformats its syntax result.
+///
+/// This function provides a convenient way to generate formatted Swift syntax nodes.
+/// The closure can generate any syntax node, which will then be automatically
+/// formatted according to the specified parameters.
+///
+/// - Parameters:
+///   - initialIndentation: The initial indentation to apply to the formatted syntax
+///   - viewMode: The view mode to use when formatting the syntax
+///   - function: The calling function (automatically provided)
+///   - fileID: The calling file (automatically provided)
+///   - line: The calling line (automatically provided)
+///   - column: The calling column (automatically provided)
+///   - closure: A closure that produces a syntax node to be formatted
+/// - Returns: The formatted equivalent of the syntax node produced by the closure
+/// - Throws: Rethrows any errors from the closure
 @inlinable
 public func withAutomaticReformatting<T>(
   initialIndentation: Trivia = Trivia(),
@@ -23,6 +39,21 @@ public func withAutomaticReformatting<T>(
   )
 }
 
+/// Executes a closure that returns a sequence of syntax nodes and automatically reformats each one.
+///
+/// This overload works with sequences of syntax nodes, formatting each node in the sequence
+/// and returning them as an array.
+///
+/// - Parameters:
+///   - initialIndentation: The initial indentation to apply to the formatted syntax
+///   - viewMode: The view mode to use when formatting the syntax
+///   - function: The calling function (automatically provided)
+///   - fileID: The calling file (automatically provided)
+///   - line: The calling line (automatically provided)
+///   - column: The calling column (automatically provided)
+///   - closure: A closure that produces a sequence of syntax nodes to be formatted
+/// - Returns: An array containing the formatted equivalents of the syntax nodes
+/// - Throws: Rethrows any errors from the closure
 @inlinable
 public func withAutomaticReformatting<T>(
   initialIndentation: Trivia = Trivia(),

--- a/Sources/MacroToolbox/Generation/Support/SyntaxProtocol+Autoformat.swift
+++ b/Sources/MacroToolbox/Generation/Support/SyntaxProtocol+Autoformat.swift
@@ -1,6 +1,20 @@
 import SwiftSyntax
 import SwiftBasicFormat
 
+/// Returns an automatically-formatted equivalent of the provided syntax node.
+///
+/// This function applies project-specific formatting rules to a syntax node.
+///
+/// - Parameters:
+///   - syntax: The syntax node to format
+///   - initialIndentation: The initial indentation to apply
+///   - viewMode: The view mode to use when formatting
+///   - function: The calling function (automatically provided)
+///   - fileID: The calling file (automatically provided)
+///   - line: The calling line (automatically provided)
+///   - column: The calling column (automatically provided)
+/// - Returns: The formatted equivalent of the input syntax node
+/// - Throws: If formatting fails
 @inlinable
 public func autoformattedEquivalent<T>(
   of syntax: T,
@@ -21,6 +35,20 @@ public func autoformattedEquivalent<T>(
   )
 }
 
+/// Returns automatically-formatted equivalents of the provided sequence of syntax nodes.
+///
+/// This function applies project-specific formatting rules to each syntax node in the sequence.
+///
+/// - Parameters:
+///   - syntaxes: The sequence of syntax nodes to format
+///   - initialIndentation: The initial indentation to apply to each node
+///   - viewMode: The view mode to use when formatting
+///   - function: The calling function (automatically provided)
+///   - fileID: The calling file (automatically provided)
+///   - line: The calling line (automatically provided)
+///   - column: The calling column (automatically provided)
+/// - Returns: An array containing the formatted equivalents of the input syntax nodes
+/// - Throws: If formatting any node fails
 @inlinable
 public func autoformattedEquivalents<T>(
   of syntaxes: some Sequence<T>,
@@ -45,6 +73,20 @@ public func autoformattedEquivalents<T>(
 
 extension SyntaxProtocol {
   
+  /// Returns a formatted version of this syntax node according to project formatting rules.
+  ///
+  /// Currently this method is a placeholder and returns the syntax node unchanged.
+  /// Future implementations may apply actual formatting rules.
+  ///
+  /// - Parameters:
+  ///   - initialIndentation: The initial indentation to apply
+  ///   - viewMode: The view mode to use when formatting
+  ///   - function: The calling function (automatically provided)
+  ///   - fileID: The calling file (automatically provided)
+  ///   - line: The calling line (automatically provided)
+  ///   - column: The calling column (automatically provided)
+  /// - Returns: The formatted syntax node (currently returns self unchanged)
+  /// - Throws: If formatting fails (not currently applicable)
   @inlinable
   public func autoFormattedForHDXLProject(
     initialIndentation: Trivia = Trivia(),

--- a/Sources/MacroToolbox/MacroProtocols/Contextualized/Attached/Macros/Accessor/AccessorMacroContext.swift
+++ b/Sources/MacroToolbox/MacroProtocols/Contextualized/Attached/Macros/Accessor/AccessorMacroContext.swift
@@ -2,17 +2,35 @@ import SwiftSyntax
 import SwiftDiagnostics
 import SwiftSyntaxMacros
 
+/// A concrete implementation of `AccessorMacroContextProtocol` that provides context for accessor macro expansion.
+///
+/// This struct encapsulates all the information needed for an accessor macro to perform its expansion,
+/// including the original macro invocation, the declaration being processed, and the expansion context.
 public struct AccessorMacroContext<Declaration, ExpansionContext>: AccessorMacroContextProtocol
 where
 Declaration: DeclSyntaxProtocol,
 ExpansionContext: MacroExpansionContext
 {
   
+  /// The original macro attribute node that triggered this expansion.
   public var macroInvocationNode: AttributeSyntax
+  
+  /// The declaration to which the macro is attached.
   public var declaration: Declaration
+  
+  /// The context in which the macro is being expanded.
   public var expansionContext: ExpansionContext
+  
+  /// A string identifier for the diagnostic domain used for error reporting.
   public var diagnosticDomainIdentifier: String
   
+  /// Creates a new accessor macro context with the specified components.
+  ///
+  /// - Parameters:
+  ///   - macroInvocationNode: The attribute syntax node representing the macro invocation
+  ///   - declaration: The declaration to which the macro is attached
+  ///   - expansionContext: The context in which the macro is being expanded
+  ///   - diagnosticDomainIdentifier: A string identifier for the diagnostic domain
   public init(
     macroInvocationNode: AttributeSyntax,
     declaration: Declaration,

--- a/Sources/MacroToolbox/MacroProtocols/Contextualized/Attached/Macros/Accessor/ContextualizedAccessorMacro.swift
+++ b/Sources/MacroToolbox/MacroProtocols/Contextualized/Attached/Macros/Accessor/ContextualizedAccessorMacro.swift
@@ -2,12 +2,32 @@ import SwiftSyntax
 import SwiftDiagnostics
 import SwiftSyntaxMacros
 
+/// A protocol for accessor macros that use contextual information during expansion.
+///
+/// This protocol builds on the standard `AccessorMacro` protocol to provide a more
+/// structured approach to macro expansion with built-in validation and contextualized
+/// information about the declaration being processed.
 public protocol ContextualizedAccessorMacro: AccessorMacro, ContextualizedAttachedMacro, DiagnosticDomainAwareMacro {
   
+  /// Performs additional validation of the expansion context before proceeding with expansion.
+  ///
+  /// This method is called after the standard validation checks and provides an opportunity
+  /// to perform macro-specific validation before expansion.
+  ///
+  /// - Parameter expansionContext: The context in which the macro is being expanded
+  /// - Throws: If the expansion context does not meet the macro's requirements
   static func validateExpansionContext(
     _ expansionContext: some AccessorMacroContextProtocol
   ) throws
 
+  /// Performs the actual macro expansion with access to the full context.
+  ///
+  /// This is the main implementation point for conforming types, where the macro's
+  /// expansion logic should be implemented.
+  ///
+  /// - Parameter attachmentContext: The context containing information about the macro invocation
+  /// - Returns: An array of accessor declarations to be added to the target property
+  /// - Throws: If the expansion fails for any reason
   static func contextualizedExpansion(
     in attachmentContext: some AccessorMacroContextProtocol
   ) throws -> [AccessorDeclSyntax]
@@ -45,6 +65,18 @@ extension ContextualizedAccessorMacro {
     return try closure(attachmentContext)
   }
 
+  /// Implements the standard `AccessorMacro` expansion method using the contextualized approach.
+  ///
+  /// This method serves as the bridge between Swift's standard macro expansion system and
+  /// the contextualized approach provided by this protocol. It handles creating the appropriate
+  /// context, performing validation, and calling the `contextualizedExpansion` method.
+  ///
+  /// - Parameters:
+  ///   - node: The attribute syntax representing the macro invocation
+  ///   - declaration: The declaration to which the macro is attached
+  ///   - context: The macro expansion context
+  /// - Returns: An array of accessor declarations to be added to the target property
+  /// - Throws: If validation or expansion fails
   public static func expansion(
     of node: AttributeSyntax,
     providingAccessorsOf declaration: some DeclSyntaxProtocol,

--- a/Sources/MacroToolbox/Model/VisibilityLevel.swift
+++ b/Sources/MacroToolbox/Model/VisibilityLevel.swift
@@ -50,6 +50,14 @@ extension VisibilityLevel: CustomDebugStringConvertible { }
 
 extension VisibilityLevel: Comparable {
   
+  /// Compares two visibility levels.
+  ///
+  /// Visibility levels are ordered from most restrictive (`private`) to least restrictive (`open`).
+  ///
+  /// - Parameters:
+  ///   - lhs: The left-hand side visibility level
+  ///   - rhs: The right-hand side visibility level
+  /// - Returns: `true` if `lhs` is more restrictive than `rhs`
   @inlinable
   public static func < (lhs: VisibilityLevel, rhs: VisibilityLevel) -> Bool {
     lhs.rawValue < rhs.rawValue
@@ -63,6 +71,9 @@ extension VisibilityLevel: Comparable {
 
 extension VisibilityLevel: MacroToolboxCaseNameAwareEnumeration {
   
+  /// Returns the case name as a string without a leading dot.
+  ///
+  /// This property is useful when generating Swift code that refers to visibility modifiers.
   @inlinable
   public var caseNameWithoutLeadingDot: String {
     switch self {
@@ -98,6 +109,10 @@ extension VisibilityLevel: TransflectableViaSourceCodeIdentifier, Transflectable
 
 extension VisibilityLevel {
   
+  /// Indicates whether this visibility level is within the "private tier".
+  ///
+  /// Returns `true` for `.private` and `.fileprivate`, and `false` for all other visibility levels.
+  /// This is useful when determining if a declaration is private to its containing module.
   @inlinable
   public var isWithinPrivateTier: Bool {
     switch self {

--- a/Sources/MacroToolboxTestSupport/MacroToolboxTestTags.swift
+++ b/Sources/MacroToolboxTestSupport/MacroToolboxTestTags.swift
@@ -3,156 +3,156 @@ import Testing
 package extension Tag {
   
   @Tag
-  static let declarationArchetype: Self
+  static var declarationArchetype: Self
 
   @Tag
-  static let explicitInlineDisposition: Self
+  static var explicitInlineDisposition: Self
   
   @Tag
-  static let inlinabilityDisposition: Self
+  static var inlinabilityDisposition: Self
   
   @Tag
-  static let visibilityLevel: Self
+  static var visibilityLevel: Self
 
   @Tag
-  static let typeDeclarationArchetype: Self
+  static var typeDeclarationArchetype: Self
     
   @Tag
-  static let macroAttachmentRequirement: Self
+  static var macroAttachmentRequirement: Self
 
   @Tag
-  static let performanceAnnotationAttachmentSite: Self
+  static var performanceAnnotationAttachmentSite: Self
   
   @Tag
-  static let syntaxInteroperation: Self
+  static var syntaxInteroperation: Self
 
 }
 
 package extension Tag {
   
   @Tag
-  static let attributeSyntax: Self
+  static var attributeSyntax: Self
   
   @Tag
-  static let tokenSyntax: Self
+  static var tokenSyntax: Self
   
   @Tag
-  static let tokenKind: Self
+  static var tokenKind: Self
   
   @Tag
-  static let keyword: Self
+  static var keyword: Self
   
   @Tag
-  static let booleanLiteralExprSyntax: Self
+  static var booleanLiteralExprSyntax: Self
   
   @Tag
-  static let integerLiteralExprSyntax: Self
+  static var integerLiteralExprSyntax: Self
   
   @Tag
-  static let floatLiteralExprSyntax: Self
+  static var floatLiteralExprSyntax: Self
   
   @Tag
-  static let simpleStringLiteralExprSyntax: Self
+  static var simpleStringLiteralExprSyntax: Self
   
   @Tag
-  static let structDeclSyntax: Self
+  static var structDeclSyntax: Self
   
   @Tag
-  static let syntaxIntrospection: Self
+  static var syntaxIntrospection: Self
 }
 
 package extension Tag {
   
   @Tag
-  static let testInfrastructure: Self 
+  static var testInfrastructure: Self 
 }
 
 package extension Tag {
   
   @Tag
-  static let positiveExamples: Self
+  static var positiveExamples: Self
 
   @Tag
-  static let negativeExamples: Self
+  static var negativeExamples: Self
   
   @Tag
-  static let unrepresentableValues: Self
+  static var unrepresentableValues: Self
 
 }
 
 package extension Tag {
 
   @Tag
-  static let optionalTransflections: Self
+  static var optionalTransflections: Self
 
   @Tag
-  static let floatingPointTransflections: Self
+  static var floatingPointTransflections: Self
 
   @Tag
-  static let integerTransflections: Self
+  static var integerTransflections: Self
 
   @Tag
-  static let signedIntegerTransflections: Self
+  static var signedIntegerTransflections: Self
 
   @Tag
-  static let unsignedIntegerTransflections: Self
+  static var unsignedIntegerTransflections: Self
 
   @Tag
-  static let booleanTransflections: Self
+  static var booleanTransflections: Self
 
   @Tag
-  static let stringTransflections: Self
+  static var stringTransflections: Self
 
   @Tag
-  static let enumerationTransflections: Self
+  static var enumerationTransflections: Self
 
   @Tag
-  static let transflection: Self
+  static var transflection: Self
 
 }
 
 package extension Tag {
   
   @Tag
-  static let float16Transflection: Self
+  static var float16Transflection: Self
 
   @Tag
-  static let floatTransflection: Self
+  static var floatTransflection: Self
 
   @Tag
-  static let doubleTransflection: Self
+  static var doubleTransflection: Self
 
   @Tag
-  static let intTransflection: Self
+  static var intTransflection: Self
 
   @Tag
-  static let int8Transflection: Self
+  static var int8Transflection: Self
 
   @Tag
-  static let int16Transflection: Self
+  static var int16Transflection: Self
 
   @Tag
-  static let int32Transflection: Self
+  static var int32Transflection: Self
 
   @Tag
-  static let int64Transflection: Self
+  static var int64Transflection: Self
 
   @Tag
-  static let uintTransflection: Self
+  static var uintTransflection: Self
 
   @Tag
-  static let uint8Transflection: Self
+  static var uint8Transflection: Self
 
   @Tag
-  static let uint16Transflection: Self
+  static var uint16Transflection: Self
 
   @Tag
-  static let uint32Transflection: Self
+  static var uint32Transflection: Self
 
   @Tag
-  static let uint64Transflection: Self
+  static var uint64Transflection: Self
 
   @Tag
-  static let stringTransflection: Self
+  static var stringTransflection: Self
 
 }

--- a/Sources/MacroToolboxTestSupport/MacroToolboxTestTags.swift
+++ b/Sources/MacroToolboxTestSupport/MacroToolboxTestTags.swift
@@ -3,144 +3,156 @@ import Testing
 package extension Tag {
   
   @Tag
-  static var declarationArchetype: Self
+  static let declarationArchetype: Self
 
   @Tag
-  static var explicitInlineDisposition: Self
+  static let explicitInlineDisposition: Self
   
   @Tag
-  static var inlinabilityDisposition: Self
+  static let inlinabilityDisposition: Self
   
   @Tag
-  static var visibilityLevel: Self
+  static let visibilityLevel: Self
 
   @Tag
-  static var typeDeclarationArchetype: Self
+  static let typeDeclarationArchetype: Self
     
   @Tag
-  static var macroAttachmentRequirement: Self
+  static let macroAttachmentRequirement: Self
 
   @Tag
-  static var performanceAnnotationAttachmentSite: Self
+  static let performanceAnnotationAttachmentSite: Self
   
   @Tag
-  static var syntaxInteroperation: Self
+  static let syntaxInteroperation: Self
 
 }
 
 package extension Tag {
   
   @Tag
-  static var attributeSyntax: Self
+  static let attributeSyntax: Self
   
   @Tag
-  static var tokenSyntax: Self
+  static let tokenSyntax: Self
   
   @Tag
-  static var tokenKind: Self
+  static let tokenKind: Self
   
   @Tag
-  static var keyword: Self
+  static let keyword: Self
   
   @Tag
-  static var booleanLiteralExprSyntax: Self
+  static let booleanLiteralExprSyntax: Self
   
   @Tag
-  static var syntaxIntrospection: Self
+  static let integerLiteralExprSyntax: Self
+  
+  @Tag
+  static let floatLiteralExprSyntax: Self
+  
+  @Tag
+  static let simpleStringLiteralExprSyntax: Self
+  
+  @Tag
+  static let structDeclSyntax: Self
+  
+  @Tag
+  static let syntaxIntrospection: Self
 }
 
 package extension Tag {
   
   @Tag
-  static var testInfrastructure: Self 
+  static let testInfrastructure: Self 
 }
 
 package extension Tag {
   
   @Tag
-  static var positiveExamples: Self
+  static let positiveExamples: Self
 
   @Tag
-  static var negativeExamples: Self
+  static let negativeExamples: Self
   
   @Tag
-  static var unrepresentableValues: Self
+  static let unrepresentableValues: Self
 
 }
 
 package extension Tag {
 
   @Tag
-  static var optionalTransflections: Self
+  static let optionalTransflections: Self
 
   @Tag
-  static var floatingPointTransflections: Self
+  static let floatingPointTransflections: Self
 
   @Tag
-  static var integerTransflections: Self
+  static let integerTransflections: Self
 
   @Tag
-  static var signedIntegerTransflections: Self
+  static let signedIntegerTransflections: Self
 
   @Tag
-  static var unsignedIntegerTransflections: Self
+  static let unsignedIntegerTransflections: Self
 
   @Tag
-  static var booleanTransflections: Self
+  static let booleanTransflections: Self
 
   @Tag
-  static var stringTransflections: Self
+  static let stringTransflections: Self
 
   @Tag
-  static var enumerationTransflections: Self
+  static let enumerationTransflections: Self
 
   @Tag
-  static var transflection: Self
+  static let transflection: Self
 
 }
 
 package extension Tag {
   
   @Tag
-  static var float16Transflection: Self
+  static let float16Transflection: Self
 
   @Tag
-  static var floatTransflection: Self
+  static let floatTransflection: Self
 
   @Tag
-  static var doubleTransflection: Self
+  static let doubleTransflection: Self
 
   @Tag
-  static var intTransflection: Self
+  static let intTransflection: Self
 
   @Tag
-  static var int8Transflection: Self
+  static let int8Transflection: Self
 
   @Tag
-  static var int16Transflection: Self
+  static let int16Transflection: Self
 
   @Tag
-  static var int32Transflection: Self
+  static let int32Transflection: Self
 
   @Tag
-  static var int64Transflection: Self
+  static let int64Transflection: Self
 
   @Tag
-  static var uintTransflection: Self
+  static let uintTransflection: Self
 
   @Tag
-  static var uint8Transflection: Self
+  static let uint8Transflection: Self
 
   @Tag
-  static var uint16Transflection: Self
+  static let uint16Transflection: Self
 
   @Tag
-  static var uint32Transflection: Self
+  static let uint32Transflection: Self
 
   @Tag
-  static var uint64Transflection: Self
+  static let uint64Transflection: Self
 
   @Tag
-  static var stringTransflection: Self
+  static let stringTransflection: Self
 
 }

--- a/Sources/MacroTransflection/Protocols/TransflectableViaDictionaryLiteral.swift
+++ b/Sources/MacroTransflection/Protocols/TransflectableViaDictionaryLiteral.swift
@@ -1,8 +1,18 @@
 
+/// A protocol for types that can be initialized from dictionary literals during macro expansion.
+/// 
+/// Conforming types can be extracted from Swift dictionary literals in macro arguments, enabling
+/// strongly-typed parameter processing in macros.
 public protocol TransflectableViaDictionaryLiteral<TransflectionDictionaryLiteralKey,TransflectionDictionaryLiteralValue>  {
+  /// The key type for the dictionary literal.
   associatedtype TransflectionDictionaryLiteralKey: Hashable
+  /// The value type for the dictionary literal.
   associatedtype TransflectionDictionaryLiteralValue
   
+  /// Creates a new instance by extracting values from a dictionary literal.
+  /// 
+  /// - Parameter dictionaryLiteralValue: The dictionary representation of the literal 
+  /// - Throws: If the dictionary literal value cannot be converted to a valid instance
   init(transflectingDictionaryLiteralValue dictionaryLiteralValue: [TransflectionDictionaryLiteralKey:TransflectionDictionaryLiteralValue]) throws
   
 }

--- a/Sources/MacroTransflection/Protocols/TransflectableViaIntegerLiteralValue.swift
+++ b/Sources/MacroTransflection/Protocols/TransflectableViaIntegerLiteralValue.swift
@@ -1,7 +1,16 @@
 
+/// A protocol for types that can be initialized from integer literal values during macro expansion.
+/// 
+/// Conforming types can be extracted from Swift integer literals in macro arguments, enabling
+/// strongly-typed parameter processing in macros.
 public protocol TransflectableViaIntegerLiteralValue<TransflectionIntegerValue> {
+  /// The integer type used for transflection.
   associatedtype TransflectionIntegerValue: FixedWidthInteger
   
+  /// Creates a new instance by extracting values from an integer literal value.
+  /// 
+  /// - Parameter integerLiteralValue: The integer value extracted from an integer literal expression
+  /// - Throws: If the integer literal value cannot be converted to a valid instance
   init(transflectingIntegerLiteralValue integerLiteralValue: TransflectionIntegerValue) throws
   
 }

--- a/Sources/MacroTransflection/Protocols/TransflectableViaNilLiteralValue.swift
+++ b/Sources/MacroTransflection/Protocols/TransflectableViaNilLiteralValue.swift
@@ -1,6 +1,14 @@
 
+/// A protocol for types that can be initialized from nil literal values during macro expansion.
+/// 
+/// Conforming types can be extracted from Swift nil literals in macro arguments, enabling
+/// strongly-typed parameter processing in macros.
 public protocol TransflectableViaNilLiteralValue {
   
+  /// Creates a new instance by extracting values from a nil literal value.
+  /// 
+  /// - Parameter nilLiteralValue: Void parameter representing the presence of a nil literal
+  /// - Throws: If the nil literal cannot be used to create a valid instance
   init(transflectingNilLiteralValue nilLiteralValue: Void) throws
   
 }

--- a/Sources/MacroTransflection/Protocols/TransflectableViaStringLiteralValue.swift
+++ b/Sources/MacroTransflection/Protocols/TransflectableViaStringLiteralValue.swift
@@ -1,6 +1,14 @@
 
+/// A protocol for types that can be initialized from string literal values during macro expansion.
+/// 
+/// Conforming types can be extracted from Swift string literals in macro arguments, enabling
+/// strongly-typed parameter processing in macros.
 public protocol TransflectableViaStringLiteralValue {
   
+  /// Creates a new instance by extracting values from a string literal value.
+  /// 
+  /// - Parameter stringLiteralValue: The string value extracted from a string literal expression
+  /// - Throws: If the string literal value cannot be converted to a valid instance
   init(transflectingStringLiteralValue stringLiteralValue: String) throws
   
 }

--- a/Tests/MacroToolboxTests/Introspection/Support/AttributeSyntax+Support+Tests.swift
+++ b/Tests/MacroToolboxTests/Introspection/Support/AttributeSyntax+Support+Tests.swift
@@ -1,0 +1,48 @@
+import Testing
+import SwiftSyntax
+import SwiftParser
+import MacroToolboxTestSupport
+@testable import MacroToolbox
+
+@Test(
+  "`AttributeSyntax` functionality",
+  .tags(
+    .syntaxIntrospection,
+    .attributeSyntax
+  )
+)
+func testAttributeSyntaxFunctionality() {
+  // Use parsing to create the attributes since direct construction is version-sensitive
+  let inlinableSource = "@inlinable func test() {}"
+  let inlinableDecl = Parser.parse(source: inlinableSource).statements.first!.item.as(DeclSyntax.self)!
+  let funcDecl = inlinableDecl.as(FunctionDeclSyntax.self)!
+  let inlinableAttr = funcDecl.attributes.first!.as(AttributeSyntax.self)!
+  
+  // Test hasName
+  #expect(inlinableAttr.hasName("inlinable") == true)
+  #expect(inlinableAttr.hasName("available") == false)
+  
+  // Test hasNoArguments
+  #expect(inlinableAttr.hasNoArguments == true)
+  
+  // Test inlinabilityDisposition
+  #expect(inlinableAttr.inlinabilityDisposition == InlinabilityDisposition.inlinable)
+  
+  // Create attribute with arguments
+  let availableSource = "@available(iOS 13.0, *) func test() {}"
+  let availableDecl = Parser.parse(source: availableSource).statements.first!.item.as(DeclSyntax.self)!
+  let availableFuncDecl = availableDecl.as(FunctionDeclSyntax.self)!
+  let availableAttr = availableFuncDecl.attributes.first!.as(AttributeSyntax.self)!
+  
+  // Test hasNoArguments for attribute with arguments
+  #expect(availableAttr.hasNoArguments == false)
+  
+  // Test argumentListAsLabeledExprList
+  #expect(availableAttr.argumentListAsLabeledExprList != nil)
+  
+  // Test inlinabilityDisposition for non-inlinable attribute
+  #expect(availableAttr.inlinabilityDisposition == nil)
+  
+  // Test hasAtSign
+  #expect(inlinableAttr.hasAtSign == true)
+}

--- a/Tests/MacroToolboxTests/Introspection/Support/FloatLiteralExprSyntax+Support+Tests.swift
+++ b/Tests/MacroToolboxTests/Introspection/Support/FloatLiteralExprSyntax+Support+Tests.swift
@@ -1,0 +1,83 @@
+import Testing
+import SwiftSyntax
+import MacroToolboxTestSupport
+@testable import MacroToolbox
+
+
+@Test(
+  "`FloatLiteralExprSyntax.representedFloatLiteralValue`",
+  .tags(
+    .syntaxIntrospection,
+    .floatLiteralExprSyntax
+  )
+)
+func testFloatLiteralExprSyntaxRepresentedFloatLiteralValue() {
+  // Test positive values
+  #expect(
+    42.5
+    ==
+    FloatLiteralExprSyntax(
+      literal: .floatLiteral("42.5")
+    ).representedFloatLiteralValue
+  )
+  
+  // Test negative values
+  #expect(
+    -123.75
+    ==
+    FloatLiteralExprSyntax(
+      literal: .floatLiteral("-123.75")
+    ).representedFloatLiteralValue
+  )
+  
+  // Test zero
+  #expect(
+    0.0
+    ==
+    FloatLiteralExprSyntax(
+      literal: .floatLiteral("0.0")
+    ).representedFloatLiteralValue
+  )
+  
+  // Test scientific notation
+  #expect(
+    1.234e5
+    ==
+    FloatLiteralExprSyntax(
+      literal: .floatLiteral("1.234e5")
+    ).representedFloatLiteralValue
+  )
+  
+  // Test with invalid float format
+  #expect(
+    nil
+    ==
+    FloatLiteralExprSyntax(
+      literal: .floatLiteral("not_a_float")
+    ).representedFloatLiteralValue
+  )
+  
+  // Test with special values
+  #expect(
+    Double.infinity
+    ==
+    FloatLiteralExprSyntax(
+      literal: .floatLiteral("Infinity")
+    ).representedFloatLiteralValue
+  )
+  
+  #expect(
+    -Double.infinity
+    ==
+    FloatLiteralExprSyntax(
+      literal: .floatLiteral("-Infinity")
+    ).representedFloatLiteralValue
+  )
+  
+  // Test with NaN (using isNaN as direct equality comparison doesn't work with NaN)
+  #expect(
+    FloatLiteralExprSyntax(
+      literal: .floatLiteral("NaN")
+    ).representedFloatLiteralValue?.isNaN == true
+  )
+}

--- a/Tests/MacroToolboxTests/Introspection/Support/FloatLiteralExprSyntax+Support+Tests.swift
+++ b/Tests/MacroToolboxTests/Introspection/Support/FloatLiteralExprSyntax+Support+Tests.swift
@@ -3,7 +3,6 @@ import SwiftSyntax
 import MacroToolboxTestSupport
 @testable import MacroToolbox
 
-
 @Test(
   "`FloatLiteralExprSyntax.representedFloatLiteralValue`",
   .tags(

--- a/Tests/MacroToolboxTests/Introspection/Support/IntegerLiteralExprSyntax+Support+Tests.swift
+++ b/Tests/MacroToolboxTests/Introspection/Support/IntegerLiteralExprSyntax+Support+Tests.swift
@@ -3,7 +3,6 @@ import SwiftSyntax
 import MacroToolboxTestSupport
 @testable import MacroToolbox
 
-
 @Test(
   "`IntegerLiteralExprSyntax.representedIntegerLiteralValue`",
   .tags(

--- a/Tests/MacroToolboxTests/Introspection/Support/IntegerLiteralExprSyntax+Support+Tests.swift
+++ b/Tests/MacroToolboxTests/Introspection/Support/IntegerLiteralExprSyntax+Support+Tests.swift
@@ -1,0 +1,110 @@
+import Testing
+import SwiftSyntax
+import MacroToolboxTestSupport
+@testable import MacroToolbox
+
+
+@Test(
+  "`IntegerLiteralExprSyntax.representedIntegerLiteralValue`",
+  .tags(
+    .syntaxIntrospection,
+    .integerLiteralExprSyntax
+  )
+)
+func testIntegerLiteralExprSyntaxRepresentedIntegerLiteralValue() {
+  #expect(
+    42
+    ==
+    IntegerLiteralExprSyntax(
+      literal: .integerLiteral("42")
+    ).representedIntegerLiteralValue
+  )
+  
+  #expect(
+    -123
+    ==
+    IntegerLiteralExprSyntax(
+      literal: .integerLiteral("-123")
+    ).representedIntegerLiteralValue
+  )
+  
+  #expect(
+    0
+    ==
+    IntegerLiteralExprSyntax(
+      literal: .integerLiteral("0")
+    ).representedIntegerLiteralValue
+  )
+  
+  // Test with invalid integer format
+  #expect(
+    nil
+    ==
+    IntegerLiteralExprSyntax(
+      literal: .integerLiteral("not_an_integer")
+    ).representedIntegerLiteralValue
+  )
+}
+
+@Test(
+  "`IntegerLiteralExprSyntax.representedValue(ofType:)`",
+  .tags(
+    .syntaxIntrospection,
+    .integerLiteralExprSyntax
+  )
+)
+func testIntegerLiteralExprSyntaxRepresentedValueOfType() {
+  // Test with UInt8
+  #expect(
+    UInt8(42)
+    ==
+    IntegerLiteralExprSyntax(
+      literal: .integerLiteral("42")
+    ).representedValue(ofType: UInt8.self)
+  )
+  
+  // Test with Int16
+  #expect(
+    Int16(-123)
+    ==
+    IntegerLiteralExprSyntax(
+      literal: .integerLiteral("-123")
+    ).representedValue(ofType: Int16.self)
+  )
+  
+  // Test with Int64
+  #expect(
+    Int64(9223372036854775807)
+    ==
+    IntegerLiteralExprSyntax(
+      literal: .integerLiteral("9223372036854775807")
+    ).representedValue(ofType: Int64.self)
+  )
+  
+  // Test with value that doesn't fit in Int but fits in UInt64
+  #expect(
+    UInt64(18446744073709551615)
+    ==
+    IntegerLiteralExprSyntax(
+      literal: .integerLiteral("18446744073709551615")
+    ).representedValue(ofType: UInt64.self)
+  )
+  
+  // Test overflow case for UInt8
+  #expect(
+    nil
+    ==
+    IntegerLiteralExprSyntax(
+      literal: .integerLiteral("256")
+    ).representedValue(ofType: UInt8.self)
+  )
+  
+  // Test invalid integer format
+  #expect(
+    nil
+    ==
+    IntegerLiteralExprSyntax(
+      literal: .integerLiteral("not_an_integer")
+    ).representedValue(ofType: Int.self)
+  )
+}

--- a/Tests/MacroToolboxTests/Introspection/Support/StructDeclSyntax+Support+Tests.swift
+++ b/Tests/MacroToolboxTests/Introspection/Support/StructDeclSyntax+Support+Tests.swift
@@ -4,7 +4,6 @@ import SwiftParser
 import MacroToolboxTestSupport
 @testable import MacroToolbox
 
-
 @Test(
   "`StructDeclSyntax.simpleGenericParameterNames`",
   .tags(
@@ -12,39 +11,28 @@ import MacroToolboxTestSupport
     .structDeclSyntax
   )
 )
-func testStructDeclSyntaxSimpleGenericParameterNames() {
+func testStructDeclSyntaxSimpleGenericParameterNames() throws {
   // Helper function to create StructDeclSyntax from source code
-  func makeStructDecl(_ source: String) -> StructDeclSyntax {
+  func makeStructDecl(_ source: String) throws -> StructDeclSyntax {
     let parsed = Parser.parse(source: source)
-    let structDecl = parsed.statements.first!.item.as(DeclSyntax.self)!
-    return structDecl.as(StructDeclSyntax.self)!
+    let statement = try #require(parsed.statements.first?.item)
+    let structDecl = try #require(statement.as(DeclSyntax.self))
+    return try #require(structDecl.as(StructDeclSyntax.self))
   }
   
   // Test struct with single generic parameter
-  #expect(
-    ["T"]
-    ==
-    makeStructDecl("struct Example<T> {}").simpleGenericParameterNames
-  )
+  let singleGenericStruct = try makeStructDecl("struct Example<T> {}")
+  #expect(["T"] == singleGenericStruct.simpleGenericParameterNames)
   
   // Test struct with multiple generic parameters
-  #expect(
-    ["K", "V"]
-    ==
-    makeStructDecl("struct Example<K, V> {}").simpleGenericParameterNames
-  )
+  let multipleGenericStruct = try makeStructDecl("struct Example<K, V> {}")
+  #expect(["K", "V"] == multipleGenericStruct.simpleGenericParameterNames)
   
   // Test struct with no generic parameters
-  #expect(
-    nil
-    ==
-    makeStructDecl("struct Example {}").simpleGenericParameterNames
-  )
+  let noGenericStruct = try makeStructDecl("struct Example {}")
+  #expect(nil == noGenericStruct.simpleGenericParameterNames)
   
   // Test struct with complex generic parameters (including constraints)
-  #expect(
-    ["T", "U"]
-    ==
-    makeStructDecl("struct Example<T: Comparable, U> where T: Hashable {}").simpleGenericParameterNames
-  )
+  let complexGenericStruct = try makeStructDecl("struct Example<T: Comparable, U> where T: Hashable {}")
+  #expect(["T", "U"] == complexGenericStruct.simpleGenericParameterNames)
 }

--- a/Tests/MacroToolboxTests/Introspection/Support/StructDeclSyntax+Support+Tests.swift
+++ b/Tests/MacroToolboxTests/Introspection/Support/StructDeclSyntax+Support+Tests.swift
@@ -1,0 +1,50 @@
+import Testing
+import SwiftSyntax
+import SwiftParser
+import MacroToolboxTestSupport
+@testable import MacroToolbox
+
+
+@Test(
+  "`StructDeclSyntax.simpleGenericParameterNames`",
+  .tags(
+    .syntaxIntrospection,
+    .structDeclSyntax
+  )
+)
+func testStructDeclSyntaxSimpleGenericParameterNames() {
+  // Helper function to create StructDeclSyntax from source code
+  func makeStructDecl(_ source: String) -> StructDeclSyntax {
+    let parsed = Parser.parse(source: source)
+    let structDecl = parsed.statements.first!.item.as(DeclSyntax.self)!
+    return structDecl.as(StructDeclSyntax.self)!
+  }
+  
+  // Test struct with single generic parameter
+  #expect(
+    ["T"]
+    ==
+    makeStructDecl("struct Example<T> {}").simpleGenericParameterNames
+  )
+  
+  // Test struct with multiple generic parameters
+  #expect(
+    ["K", "V"]
+    ==
+    makeStructDecl("struct Example<K, V> {}").simpleGenericParameterNames
+  )
+  
+  // Test struct with no generic parameters
+  #expect(
+    nil
+    ==
+    makeStructDecl("struct Example {}").simpleGenericParameterNames
+  )
+  
+  // Test struct with complex generic parameters (including constraints)
+  #expect(
+    ["T", "U"]
+    ==
+    makeStructDecl("struct Example<T: Comparable, U> where T: Hashable {}").simpleGenericParameterNames
+  )
+}


### PR DESCRIPTION
This was performed fully-automatedly by giving Claude Code the following prompt (and then hitting enter a few times):

> Please read through the non-test code in this package and find all public methods that do not have a documentation comment. For each public method without a documentation comment, please generate a documentation comment. For computed properties, subscripts, and simple functions a single explanatory line will generally suffice. For complex functions, please include a discussion where beneficial. Do not generate parameter-by-parameter explanations within the documentation except for functions presenting a significant risk of confusion to callers.
