### PR TITLE
Expand syntax introspection/generation helpers and test coverage

### DIFF
--- a/Sources/MacroToolbox/Diagnostics/MacroDiagnosticDomain+HDXLMacroDiagnostic.swift
+++ b/Sources/MacroToolbox/Diagnostics/MacroDiagnosticDomain+HDXLMacroDiagnostic.swift
@@ -37,19 +37,15 @@ extension MacroDiagnosticDomain {
     highlights: [Syntax]? = nil,
     notes: [Note] = [],
     fixIts: [FixIt] = []
-  ) -> DiagnosticsError {
-    DiagnosticsError(
-      diagnostics: [
-        _diagnosticWarning(
-          for: node,
-          at: position,
-          explanation: explanation,
-          messageID: messageID,
-          highlights: highlights,
-          notes: notes,
-          fixIts: fixIts
-        )
-      ]
+  ) -> Diagnostic {
+    _diagnosticWarning(
+      for: node,
+      at: position,
+      explanation: explanation,
+      messageID: messageID,
+      highlights: highlights,
+      notes: notes,
+      fixIts: fixIts
     )
   }
   
@@ -62,19 +58,15 @@ extension MacroDiagnosticDomain {
     highlights: [Syntax]? = nil,
     notes: [Note] = [],
     fixIts: [FixIt] = []
-  ) -> DiagnosticsError {
-    DiagnosticsError(
-      diagnostics: [
-        _diagnosticNote(
-          for: node,
-          at: position,
-          explanation: explanation,
-          messageID: messageID,
-          highlights: highlights,
-          notes: notes,
-          fixIts: fixIts
-        )
-      ]
+  ) -> Diagnostic {
+    _diagnosticNote(
+      for: node,
+      at: position,
+      explanation: explanation,
+      messageID: messageID,
+      highlights: highlights,
+      notes: notes,
+      fixIts: fixIts
     )
   }
   
@@ -87,19 +79,15 @@ extension MacroDiagnosticDomain {
     highlights: [Syntax]? = nil,
     notes: [Note] = [],
     fixIts: [FixIt] = []
-  ) -> DiagnosticsError {
-    DiagnosticsError(
-      diagnostics: [
-        _diagnosticRemark(
-          for: node,
-          at: position,
-          explanation: explanation,
-          messageID: messageID,
-          highlights: highlights,
-          notes: notes,
-          fixIts: fixIts
-        )
-      ]
+  ) -> Diagnostic {
+    _diagnosticRemark(
+      for: node,
+      at: position,
+      explanation: explanation,
+      messageID: messageID,
+      highlights: highlights,
+      notes: notes,
+      fixIts: fixIts
     )
   }
   
@@ -222,4 +210,3 @@ extension MacroDiagnosticDomain {
   }
   
 }
-

--- a/Sources/MacroToolbox/Generation/Builders/StoredPropertyDeclaration.swift
+++ b/Sources/MacroToolbox/Generation/Builders/StoredPropertyDeclaration.swift
@@ -44,7 +44,7 @@ extension StoredProperty: ConcreteDeclSyntaxDeclaration, DeclSyntaxDeclaration {
   }
   
   internal var setterVisibilityDeclaration: String? {
-    visibility.map {
+    setterVisibility.map {
       "\($0.sourceCodeStringRepresentation)(set)"
     }
   }
@@ -113,4 +113,3 @@ public protocol DeclSyntaxDeclaration {
   func makeDeclSyntax() throws -> DeclSyntax
   
 }
-

--- a/Sources/MacroToolbox/Generation/Support/DeclSyntaxProtocol+TypeErasure.swift
+++ b/Sources/MacroToolbox/Generation/Support/DeclSyntaxProtocol+TypeErasure.swift
@@ -1,8 +1,22 @@
 import SwiftSyntax
 import SwiftSyntaxBuilder
 
+extension SyntaxProtocol {
+
+  @inlinable
+  public func eraseToSyntax() -> Syntax {
+    Syntax(self)
+  }
+
+  @inlinable
+  public func eraseToValidatedSyntax() throws -> Syntax {
+    try Syntax(validating: eraseToSyntax())
+  }
+
+}
+
 extension DeclSyntaxProtocol {
-  
+
   @inlinable
   public func eraseToDeclSyntax() -> DeclSyntax {
     DeclSyntax(self)
@@ -11,6 +25,62 @@ extension DeclSyntaxProtocol {
   @inlinable
   public func eraseToValidatedDeclSyntax() throws -> DeclSyntax {
     try DeclSyntax(validating: eraseToDeclSyntax())
+  }
+
+}
+
+extension ExprSyntaxProtocol {
+
+  @inlinable
+  public func eraseToExprSyntax() -> ExprSyntax {
+    ExprSyntax(self)
+  }
+
+  @inlinable
+  public func eraseToValidatedExprSyntax() throws -> ExprSyntax {
+    try ExprSyntax(validating: eraseToExprSyntax())
+  }
+
+}
+
+extension PatternSyntaxProtocol {
+
+  @inlinable
+  public func eraseToPatternSyntax() -> PatternSyntax {
+    PatternSyntax(self)
+  }
+
+  @inlinable
+  public func eraseToValidatedPatternSyntax() throws -> PatternSyntax {
+    try PatternSyntax(validating: eraseToPatternSyntax())
+  }
+
+}
+
+extension StmtSyntaxProtocol {
+
+  @inlinable
+  public func eraseToStmtSyntax() -> StmtSyntax {
+    StmtSyntax(self)
+  }
+
+  @inlinable
+  public func eraseToValidatedStmtSyntax() throws -> StmtSyntax {
+    try StmtSyntax(validating: eraseToStmtSyntax())
+  }
+
+}
+
+extension TypeSyntaxProtocol {
+
+  @inlinable
+  public func eraseToTypeSyntax() -> TypeSyntax {
+    TypeSyntax(self)
+  }
+
+  @inlinable
+  public func eraseToValidatedTypeSyntax() throws -> TypeSyntax {
+    try TypeSyntax(validating: eraseToTypeSyntax())
   }
 
 }

--- a/Sources/MacroToolbox/Generation/Support/GenericRequirementSyntax+Generation.swift
+++ b/Sources/MacroToolbox/Generation/Support/GenericRequirementSyntax+Generation.swift
@@ -12,6 +12,7 @@ extension GenericRequirementSyntax {
           leftType: IdentifierTypeSyntax.forType(
             named: typeName
           ),
+          colon: .colonToken(trailingTrivia: .space),
           rightType: IdentifierTypeSyntax.forType(
             named: otherTypeName
           )

--- a/Sources/MacroToolbox/Generation/Support/GenericWhereClauseSyntax+Generation.swift
+++ b/Sources/MacroToolbox/Generation/Support/GenericWhereClauseSyntax+Generation.swift
@@ -5,6 +5,7 @@ extension GenericWhereClauseSyntax {
   @inlinable
   public init(requirements: some Collection<GenericRequirementSyntax>) {
     self.init(
+      whereKeyword: .keyword(.where, trailingTrivia: .space),
       requirements: GenericRequirementListSyntax(
         withTrailingCommasInsertedBetween: requirements
       )

--- a/Sources/MacroToolbox/Generation/Support/InheritanceClauseSyntax+Generation.swift
+++ b/Sources/MacroToolbox/Generation/Support/InheritanceClauseSyntax+Generation.swift
@@ -12,6 +12,7 @@ extension InheritanceClauseSyntax {
   @inlinable
   public static func forInheritedTypeNames(_ inheritedTypeNames: some Sequence<String>)-> Self {
     InheritanceClauseSyntax(
+      colon: .colonToken(trailingTrivia: .space),
       inheritedTypes: .forTypeNames(inheritedTypeNames)
     )
   }

--- a/Sources/MacroToolbox/Generation/Support/MemberBlockSyntax+Generation.swift
+++ b/Sources/MacroToolbox/Generation/Support/MemberBlockSyntax+Generation.swift
@@ -5,6 +5,7 @@ extension MemberBlockSyntax {
   @inlinable
   public init(declarations: some Sequence<some DeclSyntaxProtocol>) {
     self.init(
+      leftBrace: .leftBraceToken(leadingTrivia: .space),
       members: MemberBlockItemListSyntax(
         declarations.map { declaration in
           MemberBlockItemSyntax(decl: declaration)

--- a/Sources/MacroToolbox/Generation/Support/SyntaxCollection+Generation.swift
+++ b/Sources/MacroToolbox/Generation/Support/SyntaxCollection+Generation.swift
@@ -33,7 +33,7 @@ extension SyntaxCollection where Element: WithTrailingCommaSyntax {
         case true:
           result.trailingComma = nil
         case false:
-          result.trailingComma = TokenSyntax.commaToken()
+          result.trailingComma = TokenSyntax.commaToken(trailingTrivia: .space)
         }
         
         return result

--- a/Sources/MacroToolbox/Generation/Support/SyntaxProtocol+SourceParsing.swift
+++ b/Sources/MacroToolbox/Generation/Support/SyntaxProtocol+SourceParsing.swift
@@ -1,0 +1,107 @@
+import SwiftParser
+import SwiftSyntax
+
+extension SyntaxProtocol {
+  
+  /// Parses `sourceCode` and returns the first syntax element of this type.
+  ///
+  /// This is intentionally broad: some syntax elements cannot be parsed as a
+  /// complete source file by themselves, but can be constructed by parsing a
+  /// larger source fragment and extracting the desired node.
+  @inlinable
+  public static func firstParsed(
+    from sourceCode: String,
+    viewMode: SyntaxTreeViewMode = .sourceAccurate,
+    function: StaticString = #function,
+    fileID: StaticString = #fileID,
+    line: UInt = #line,
+    column: UInt = #column
+  ) throws -> Self {
+    let sourceFile = Parser.parse(source: sourceCode)
+    guard let result = sourceFile.firstSyntaxElement(
+      ofType: Self.self,
+      viewMode: viewMode
+    ) else {
+      throw MacroExpansionFailure(
+        explanation: "Unable to find \(String(reflecting: Self.self)) in parsed source.",
+        function: function,
+        fileID: fileID,
+        line: line,
+        column: column
+      )
+    }
+    
+    return result
+  }
+  
+  /// Parses `sourceCode` and initializes `self` with the first syntax element of this type.
+  @inlinable
+  public init(
+    firstParsedFrom sourceCode: String,
+    viewMode: SyntaxTreeViewMode = .sourceAccurate,
+    function: StaticString = #function,
+    fileID: StaticString = #fileID,
+    line: UInt = #line,
+    column: UInt = #column
+  ) throws {
+    self = try Self.firstParsed(
+      from: sourceCode,
+      viewMode: viewMode,
+      function: function,
+      fileID: fileID,
+      line: line,
+      column: column
+    )
+  }
+  
+  /// Parses `sourceCode` and returns the only syntax element of this type.
+  @inlinable
+  public static func onlyParsed(
+    from sourceCode: String,
+    viewMode: SyntaxTreeViewMode = .sourceAccurate,
+    function: StaticString = #function,
+    fileID: StaticString = #fileID,
+    line: UInt = #line,
+    column: UInt = #column
+  ) throws -> Self {
+    let matches = Parser
+      .parse(source: sourceCode)
+      .allSyntaxElements(
+        ofType: Self.self,
+        viewMode: viewMode
+      )
+    
+    guard matches.count == 1, let result = matches.first else {
+      throw MacroExpansionFailure(
+        explanation: "Expected exactly one \(String(reflecting: Self.self)) in parsed source; found \(matches.count).",
+        function: function,
+        fileID: fileID,
+        line: line,
+        column: column
+      )
+    }
+    
+    return result
+  }
+  
+  /// Parses `sourceCode` and initializes `self` with its only syntax element of this type.
+  @inlinable
+  public init(
+    onlyParsedFrom sourceCode: String,
+    viewMode: SyntaxTreeViewMode = .sourceAccurate,
+    function: StaticString = #function,
+    fileID: StaticString = #fileID,
+    line: UInt = #line,
+    column: UInt = #column
+  ) throws {
+    self = try Self.onlyParsed(
+      from: sourceCode,
+      viewMode: viewMode,
+      function: function,
+      fileID: fileID,
+      line: line,
+      column: column
+    )
+  }
+  
+}

--- a/Sources/MacroToolbox/Introspection/Support/DeclSyntaxProtocol+Support.swift
+++ b/Sources/MacroToolbox/Introspection/Support/DeclSyntaxProtocol+Support.swift
@@ -1,6 +1,78 @@
 import SwiftSyntax
 import SwiftSyntaxMacros
 
+@inlinable
+func _updateConcreteTypeMappingResult<Declaration, R, T>(
+  _ result: inout R?,
+  foundMatch: inout Bool,
+  declaration: Declaration,
+  association: (R, T.Type)
+)
+where
+  Declaration: DeclSyntaxProtocol,
+  T: DeclSyntaxProtocol
+{
+  guard !foundMatch else {
+    return
+  }
+
+  let (value, concreteType) = association
+  guard declaration.is(concreteType) else {
+    return
+  }
+
+  foundMatch = true
+  result = value
+}
+
+@inlinable
+func _updateHomogeneousValueResult<Declaration, R, T>(
+  _ result: inout R?,
+  foundMatch: inout Bool,
+  declaration: Declaration,
+  association: (KeyPath<T, R>, T.Type)
+)
+where
+  Declaration: DeclSyntaxProtocol,
+  T: DeclSyntaxProtocol
+{
+  guard !foundMatch else {
+    return
+  }
+
+  let (keyPath, concreteType) = association
+  guard let concreteValue = declaration.as(concreteType) else {
+    return
+  }
+
+  foundMatch = true
+  result = concreteValue[keyPath: keyPath]
+}
+
+@inlinable
+func _updateOptionalHomogeneousValueResult<Declaration, R, T>(
+  _ result: inout R?,
+  foundMatch: inout Bool,
+  declaration: Declaration,
+  association: (KeyPath<T, R?>, T.Type)
+)
+where
+  Declaration: DeclSyntaxProtocol,
+  T: DeclSyntaxProtocol
+{
+  guard !foundMatch else {
+    return
+  }
+
+  let (keyPath, concreteType) = association
+  guard let concreteValue = declaration.as(concreteType) else {
+    return
+  }
+
+  foundMatch = true
+  result = concreteValue[keyPath: keyPath]
+}
+
 extension DeclSyntaxProtocol {
 
   /// Maps `self` to the supplied value that's associated-with `self`'s type.
@@ -35,13 +107,18 @@ extension DeclSyntaxProtocol {
   public func applyConcreteTypeMapping<R, each T: DeclSyntaxProtocol>(
     associations: (repeat (R, (each T).Type))
   ) -> R? {
-    for (value, concreteType) in repeat each associations {
-      if self.is(concreteType) {
-        return value
-      }
-    }
-    
-    return nil
+    var result: R?
+    var foundMatch = false
+    _ = (
+      repeat _updateConcreteTypeMappingResult(
+        &result,
+        foundMatch: &foundMatch,
+        declaration: self,
+        association: each associations
+      )
+    )
+
+    return result
   }
 
   /// Given a list of pairs like ("possible type, keypath-on-type"), returns the appropriate value from `self` (or `nil`, if `self` isn't any of the supplied types).
@@ -56,13 +133,18 @@ extension DeclSyntaxProtocol {
   public func extractHomogeneousValues<R, each T: DeclSyntaxProtocol>(
     using associations: (repeat (KeyPath<each T,R>, (each T).Type))
   ) -> R? {
-    for (keyPath, concreteType) in repeat each associations {
-      if let concreteValue = self.as(concreteType) {
-        return concreteValue[keyPath: keyPath]
-      }
-    }
-    
-    return nil
+    var result: R?
+    var foundMatch = false
+    _ = (
+      repeat _updateHomogeneousValueResult(
+        &result,
+        foundMatch: &foundMatch,
+        declaration: self,
+        association: each associations
+      )
+    )
+
+    return result
   }
 
   /// Extracts homogeneously-typed values from `self`, if possible, using the first successful type-and-keypath pair.
@@ -77,13 +159,18 @@ extension DeclSyntaxProtocol {
   public func extractHomogeneousValues<R, each T: DeclSyntaxProtocol>(
     using associations: (repeat (KeyPath<each T,R?>, (each T).Type))
   ) -> R? {
-    for (keyPath, concreteType) in repeat each associations {
-      if let concreteValue = self.as(concreteType) {
-        return concreteValue[keyPath: keyPath]
-      }
-    }
-    
-    return nil
+    var result: R?
+    var foundMatch = false
+    _ = (
+      repeat _updateOptionalHomogeneousValueResult(
+        &result,
+        foundMatch: &foundMatch,
+        declaration: self,
+        association: each associations
+      )
+    )
+
+    return result
   }
 
   @inlinable
@@ -98,7 +185,7 @@ extension DeclSyntaxProtocol {
       )
     )
   }
-  
+
   @inlinable
   public var declarationArchetype: DeclarationArchetype? {
     applyConcreteTypeMapping(
@@ -130,6 +217,5 @@ extension DeclSyntaxProtocol {
       )
     )
   }
-  
-}
 
+}

--- a/Sources/MacroToolbox/Introspection/Support/EnumCaseElementListSyntax+Support.swift
+++ b/Sources/MacroToolbox/Introspection/Support/EnumCaseElementListSyntax+Support.swift
@@ -1,15 +1,20 @@
 import SwiftSyntax
 
 extension EnumCaseElementListSyntax {
-  
+
   /// `true` iff this element-list is for a single-element declaration, sans payload.
   @inlinable
   public var isSimpleCaseWithoutPayload: Bool {
-    count == 1
-    &&
-    (first?.isSimpleCaseWithoutPayload ?? false)
+    guard
+      count == 1,
+      let caseElement = first
+    else {
+      return false
+    }
+
+    return caseElement.isSimpleCaseWithoutPayload
   }
-  
+
   /// Returns the enumeration case's name, *provided that* we're a single-case declaration.
   @inlinable
   public var primarySourceCodeIdentifier: TokenSyntax? {
@@ -19,7 +24,7 @@ extension EnumCaseElementListSyntax {
     else {
       return nil
     }
-    
+
     return caseElement.name.trimmed
   }
 

--- a/Sources/MacroToolbox/Introspection/Support/SyntaxProtocol+ElementCasts.swift
+++ b/Sources/MacroToolbox/Introspection/Support/SyntaxProtocol+ElementCasts.swift
@@ -1,0 +1,3417 @@
+import SwiftSyntax
+
+extension SyntaxProtocol {
+
+  /// Returns `self` as `type`, when possible.
+  @inlinable
+  public func asSyntaxElement<T>(
+    _ type: T.Type = T.self
+  ) -> T? where T: SyntaxProtocol {
+    self.as(type)
+  }
+
+  /// `true` iff `self` can be viewed as `type`.
+  @inlinable
+  public func isSyntaxElement<T>(
+    _ type: T.Type = T.self
+  ) -> Bool where T: SyntaxProtocol {
+    self.is(type)
+  }
+
+  /// Returns `self` as `ABIAttributeArgumentsSyntax`, when possible.
+  @inlinable
+  public var asABIAttributeArgumentsSyntax: ABIAttributeArgumentsSyntax? {
+    self.as(ABIAttributeArgumentsSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ABIAttributeArgumentsSyntax`.
+  @inlinable
+  public var isABIAttributeArgumentsSyntax: Bool {
+    self.is(ABIAttributeArgumentsSyntax.self)
+  }
+
+  /// Returns `self` as `AccessorBlockSyntax`, when possible.
+  @inlinable
+  public var asAccessorBlockSyntax: AccessorBlockSyntax? {
+    self.as(AccessorBlockSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `AccessorBlockSyntax`.
+  @inlinable
+  public var isAccessorBlockSyntax: Bool {
+    self.is(AccessorBlockSyntax.self)
+  }
+
+  /// Returns `self` as `AccessorDeclListSyntax`, when possible.
+  @inlinable
+  public var asAccessorDeclListSyntax: AccessorDeclListSyntax? {
+    self.as(AccessorDeclListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `AccessorDeclListSyntax`.
+  @inlinable
+  public var isAccessorDeclListSyntax: Bool {
+    self.is(AccessorDeclListSyntax.self)
+  }
+
+  /// Returns `self` as `AccessorDeclSyntax`, when possible.
+  @inlinable
+  public var asAccessorDeclSyntax: AccessorDeclSyntax? {
+    self.as(AccessorDeclSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `AccessorDeclSyntax`.
+  @inlinable
+  public var isAccessorDeclSyntax: Bool {
+    self.is(AccessorDeclSyntax.self)
+  }
+
+  /// Returns `self` as `AccessorEffectSpecifiersSyntax`, when possible.
+  @inlinable
+  public var asAccessorEffectSpecifiersSyntax: AccessorEffectSpecifiersSyntax? {
+    self.as(AccessorEffectSpecifiersSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `AccessorEffectSpecifiersSyntax`.
+  @inlinable
+  public var isAccessorEffectSpecifiersSyntax: Bool {
+    self.is(AccessorEffectSpecifiersSyntax.self)
+  }
+
+  /// Returns `self` as `AccessorParametersSyntax`, when possible.
+  @inlinable
+  public var asAccessorParametersSyntax: AccessorParametersSyntax? {
+    self.as(AccessorParametersSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `AccessorParametersSyntax`.
+  @inlinable
+  public var isAccessorParametersSyntax: Bool {
+    self.is(AccessorParametersSyntax.self)
+  }
+
+  /// Returns `self` as `ActorDeclSyntax`, when possible.
+  @inlinable
+  public var asActorDeclSyntax: ActorDeclSyntax? {
+    self.as(ActorDeclSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ActorDeclSyntax`.
+  @inlinable
+  public var isActorDeclSyntax: Bool {
+    self.is(ActorDeclSyntax.self)
+  }
+
+  /// Returns `self` as `ArrayElementListSyntax`, when possible.
+  @inlinable
+  public var asArrayElementListSyntax: ArrayElementListSyntax? {
+    self.as(ArrayElementListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ArrayElementListSyntax`.
+  @inlinable
+  public var isArrayElementListSyntax: Bool {
+    self.is(ArrayElementListSyntax.self)
+  }
+
+  /// Returns `self` as `ArrayElementSyntax`, when possible.
+  @inlinable
+  public var asArrayElementSyntax: ArrayElementSyntax? {
+    self.as(ArrayElementSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ArrayElementSyntax`.
+  @inlinable
+  public var isArrayElementSyntax: Bool {
+    self.is(ArrayElementSyntax.self)
+  }
+
+  /// Returns `self` as `ArrayExprSyntax`, when possible.
+  @inlinable
+  public var asArrayExprSyntax: ArrayExprSyntax? {
+    self.as(ArrayExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ArrayExprSyntax`.
+  @inlinable
+  public var isArrayExprSyntax: Bool {
+    self.is(ArrayExprSyntax.self)
+  }
+
+  /// Returns `self` as `ArrayTypeSyntax`, when possible.
+  @inlinable
+  public var asArrayTypeSyntax: ArrayTypeSyntax? {
+    self.as(ArrayTypeSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ArrayTypeSyntax`.
+  @inlinable
+  public var isArrayTypeSyntax: Bool {
+    self.is(ArrayTypeSyntax.self)
+  }
+
+  /// Returns `self` as `ArrowExprSyntax`, when possible.
+  @inlinable
+  public var asArrowExprSyntax: ArrowExprSyntax? {
+    self.as(ArrowExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ArrowExprSyntax`.
+  @inlinable
+  public var isArrowExprSyntax: Bool {
+    self.is(ArrowExprSyntax.self)
+  }
+
+  /// Returns `self` as `AsExprSyntax`, when possible.
+  @inlinable
+  public var asAsExprSyntax: AsExprSyntax? {
+    self.as(AsExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `AsExprSyntax`.
+  @inlinable
+  public var isAsExprSyntax: Bool {
+    self.is(AsExprSyntax.self)
+  }
+
+  /// Returns `self` as `AssignmentExprSyntax`, when possible.
+  @inlinable
+  public var asAssignmentExprSyntax: AssignmentExprSyntax? {
+    self.as(AssignmentExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `AssignmentExprSyntax`.
+  @inlinable
+  public var isAssignmentExprSyntax: Bool {
+    self.is(AssignmentExprSyntax.self)
+  }
+
+  /// Returns `self` as `AssociatedTypeDeclSyntax`, when possible.
+  @inlinable
+  public var asAssociatedTypeDeclSyntax: AssociatedTypeDeclSyntax? {
+    self.as(AssociatedTypeDeclSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `AssociatedTypeDeclSyntax`.
+  @inlinable
+  public var isAssociatedTypeDeclSyntax: Bool {
+    self.is(AssociatedTypeDeclSyntax.self)
+  }
+
+  /// Returns `self` as `AttributeListSyntax`, when possible.
+  @inlinable
+  public var asAttributeListSyntax: AttributeListSyntax? {
+    self.as(AttributeListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `AttributeListSyntax`.
+  @inlinable
+  public var isAttributeListSyntax: Bool {
+    self.is(AttributeListSyntax.self)
+  }
+
+  /// Returns `self` as `AttributeSyntax`, when possible.
+  @inlinable
+  public var asAttributeSyntax: AttributeSyntax? {
+    self.as(AttributeSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `AttributeSyntax`.
+  @inlinable
+  public var isAttributeSyntax: Bool {
+    self.is(AttributeSyntax.self)
+  }
+
+  /// Returns `self` as `AttributedTypeSyntax`, when possible.
+  @inlinable
+  public var asAttributedTypeSyntax: AttributedTypeSyntax? {
+    self.as(AttributedTypeSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `AttributedTypeSyntax`.
+  @inlinable
+  public var isAttributedTypeSyntax: Bool {
+    self.is(AttributedTypeSyntax.self)
+  }
+
+  /// Returns `self` as `AvailabilityArgumentListSyntax`, when possible.
+  @inlinable
+  public var asAvailabilityArgumentListSyntax: AvailabilityArgumentListSyntax? {
+    self.as(AvailabilityArgumentListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `AvailabilityArgumentListSyntax`.
+  @inlinable
+  public var isAvailabilityArgumentListSyntax: Bool {
+    self.is(AvailabilityArgumentListSyntax.self)
+  }
+
+  /// Returns `self` as `AvailabilityArgumentSyntax`, when possible.
+  @inlinable
+  public var asAvailabilityArgumentSyntax: AvailabilityArgumentSyntax? {
+    self.as(AvailabilityArgumentSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `AvailabilityArgumentSyntax`.
+  @inlinable
+  public var isAvailabilityArgumentSyntax: Bool {
+    self.is(AvailabilityArgumentSyntax.self)
+  }
+
+  /// Returns `self` as `AvailabilityConditionSyntax`, when possible.
+  @inlinable
+  public var asAvailabilityConditionSyntax: AvailabilityConditionSyntax? {
+    self.as(AvailabilityConditionSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `AvailabilityConditionSyntax`.
+  @inlinable
+  public var isAvailabilityConditionSyntax: Bool {
+    self.is(AvailabilityConditionSyntax.self)
+  }
+
+  /// Returns `self` as `AvailabilityLabeledArgumentSyntax`, when possible.
+  @inlinable
+  public var asAvailabilityLabeledArgumentSyntax: AvailabilityLabeledArgumentSyntax? {
+    self.as(AvailabilityLabeledArgumentSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `AvailabilityLabeledArgumentSyntax`.
+  @inlinable
+  public var isAvailabilityLabeledArgumentSyntax: Bool {
+    self.is(AvailabilityLabeledArgumentSyntax.self)
+  }
+
+  /// Returns `self` as `AwaitExprSyntax`, when possible.
+  @inlinable
+  public var asAwaitExprSyntax: AwaitExprSyntax? {
+    self.as(AwaitExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `AwaitExprSyntax`.
+  @inlinable
+  public var isAwaitExprSyntax: Bool {
+    self.is(AwaitExprSyntax.self)
+  }
+
+  /// Returns `self` as `BackDeployedAttributeArgumentsSyntax`, when possible.
+  @inlinable
+  public var asBackDeployedAttributeArgumentsSyntax: BackDeployedAttributeArgumentsSyntax? {
+    self.as(BackDeployedAttributeArgumentsSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `BackDeployedAttributeArgumentsSyntax`.
+  @inlinable
+  public var isBackDeployedAttributeArgumentsSyntax: Bool {
+    self.is(BackDeployedAttributeArgumentsSyntax.self)
+  }
+
+  /// Returns `self` as `BinaryOperatorExprSyntax`, when possible.
+  @inlinable
+  public var asBinaryOperatorExprSyntax: BinaryOperatorExprSyntax? {
+    self.as(BinaryOperatorExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `BinaryOperatorExprSyntax`.
+  @inlinable
+  public var isBinaryOperatorExprSyntax: Bool {
+    self.is(BinaryOperatorExprSyntax.self)
+  }
+
+  /// Returns `self` as `BooleanLiteralExprSyntax`, when possible.
+  @inlinable
+  public var asBooleanLiteralExprSyntax: BooleanLiteralExprSyntax? {
+    self.as(BooleanLiteralExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `BooleanLiteralExprSyntax`.
+  @inlinable
+  public var isBooleanLiteralExprSyntax: Bool {
+    self.is(BooleanLiteralExprSyntax.self)
+  }
+
+  /// Returns `self` as `BorrowExprSyntax`, when possible.
+  @inlinable
+  public var asBorrowExprSyntax: BorrowExprSyntax? {
+    self.as(BorrowExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `BorrowExprSyntax`.
+  @inlinable
+  public var isBorrowExprSyntax: Bool {
+    self.is(BorrowExprSyntax.self)
+  }
+
+  /// Returns `self` as `BreakStmtSyntax`, when possible.
+  @inlinable
+  public var asBreakStmtSyntax: BreakStmtSyntax? {
+    self.as(BreakStmtSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `BreakStmtSyntax`.
+  @inlinable
+  public var isBreakStmtSyntax: Bool {
+    self.is(BreakStmtSyntax.self)
+  }
+
+  /// Returns `self` as `CatchClauseListSyntax`, when possible.
+  @inlinable
+  public var asCatchClauseListSyntax: CatchClauseListSyntax? {
+    self.as(CatchClauseListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `CatchClauseListSyntax`.
+  @inlinable
+  public var isCatchClauseListSyntax: Bool {
+    self.is(CatchClauseListSyntax.self)
+  }
+
+  /// Returns `self` as `CatchClauseSyntax`, when possible.
+  @inlinable
+  public var asCatchClauseSyntax: CatchClauseSyntax? {
+    self.as(CatchClauseSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `CatchClauseSyntax`.
+  @inlinable
+  public var isCatchClauseSyntax: Bool {
+    self.is(CatchClauseSyntax.self)
+  }
+
+  /// Returns `self` as `CatchItemListSyntax`, when possible.
+  @inlinable
+  public var asCatchItemListSyntax: CatchItemListSyntax? {
+    self.as(CatchItemListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `CatchItemListSyntax`.
+  @inlinable
+  public var isCatchItemListSyntax: Bool {
+    self.is(CatchItemListSyntax.self)
+  }
+
+  /// Returns `self` as `CatchItemSyntax`, when possible.
+  @inlinable
+  public var asCatchItemSyntax: CatchItemSyntax? {
+    self.as(CatchItemSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `CatchItemSyntax`.
+  @inlinable
+  public var isCatchItemSyntax: Bool {
+    self.is(CatchItemSyntax.self)
+  }
+
+  /// Returns `self` as `ClassDeclSyntax`, when possible.
+  @inlinable
+  public var asClassDeclSyntax: ClassDeclSyntax? {
+    self.as(ClassDeclSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ClassDeclSyntax`.
+  @inlinable
+  public var isClassDeclSyntax: Bool {
+    self.is(ClassDeclSyntax.self)
+  }
+
+  /// Returns `self` as `ClassRestrictionTypeSyntax`, when possible.
+  @inlinable
+  public var asClassRestrictionTypeSyntax: ClassRestrictionTypeSyntax? {
+    self.as(ClassRestrictionTypeSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ClassRestrictionTypeSyntax`.
+  @inlinable
+  public var isClassRestrictionTypeSyntax: Bool {
+    self.is(ClassRestrictionTypeSyntax.self)
+  }
+
+  /// Returns `self` as `ClosureCaptureClauseSyntax`, when possible.
+  @inlinable
+  public var asClosureCaptureClauseSyntax: ClosureCaptureClauseSyntax? {
+    self.as(ClosureCaptureClauseSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ClosureCaptureClauseSyntax`.
+  @inlinable
+  public var isClosureCaptureClauseSyntax: Bool {
+    self.is(ClosureCaptureClauseSyntax.self)
+  }
+
+  /// Returns `self` as `ClosureCaptureListSyntax`, when possible.
+  @inlinable
+  public var asClosureCaptureListSyntax: ClosureCaptureListSyntax? {
+    self.as(ClosureCaptureListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ClosureCaptureListSyntax`.
+  @inlinable
+  public var isClosureCaptureListSyntax: Bool {
+    self.is(ClosureCaptureListSyntax.self)
+  }
+
+  /// Returns `self` as `ClosureCaptureSpecifierSyntax`, when possible.
+  @inlinable
+  public var asClosureCaptureSpecifierSyntax: ClosureCaptureSpecifierSyntax? {
+    self.as(ClosureCaptureSpecifierSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ClosureCaptureSpecifierSyntax`.
+  @inlinable
+  public var isClosureCaptureSpecifierSyntax: Bool {
+    self.is(ClosureCaptureSpecifierSyntax.self)
+  }
+
+  /// Returns `self` as `ClosureCaptureSyntax`, when possible.
+  @inlinable
+  public var asClosureCaptureSyntax: ClosureCaptureSyntax? {
+    self.as(ClosureCaptureSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ClosureCaptureSyntax`.
+  @inlinable
+  public var isClosureCaptureSyntax: Bool {
+    self.is(ClosureCaptureSyntax.self)
+  }
+
+  /// Returns `self` as `ClosureExprSyntax`, when possible.
+  @inlinable
+  public var asClosureExprSyntax: ClosureExprSyntax? {
+    self.as(ClosureExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ClosureExprSyntax`.
+  @inlinable
+  public var isClosureExprSyntax: Bool {
+    self.is(ClosureExprSyntax.self)
+  }
+
+  /// Returns `self` as `ClosureParameterClauseSyntax`, when possible.
+  @inlinable
+  public var asClosureParameterClauseSyntax: ClosureParameterClauseSyntax? {
+    self.as(ClosureParameterClauseSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ClosureParameterClauseSyntax`.
+  @inlinable
+  public var isClosureParameterClauseSyntax: Bool {
+    self.is(ClosureParameterClauseSyntax.self)
+  }
+
+  /// Returns `self` as `ClosureParameterListSyntax`, when possible.
+  @inlinable
+  public var asClosureParameterListSyntax: ClosureParameterListSyntax? {
+    self.as(ClosureParameterListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ClosureParameterListSyntax`.
+  @inlinable
+  public var isClosureParameterListSyntax: Bool {
+    self.is(ClosureParameterListSyntax.self)
+  }
+
+  /// Returns `self` as `ClosureParameterSyntax`, when possible.
+  @inlinable
+  public var asClosureParameterSyntax: ClosureParameterSyntax? {
+    self.as(ClosureParameterSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ClosureParameterSyntax`.
+  @inlinable
+  public var isClosureParameterSyntax: Bool {
+    self.is(ClosureParameterSyntax.self)
+  }
+
+  /// Returns `self` as `ClosureShorthandParameterListSyntax`, when possible.
+  @inlinable
+  public var asClosureShorthandParameterListSyntax: ClosureShorthandParameterListSyntax? {
+    self.as(ClosureShorthandParameterListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ClosureShorthandParameterListSyntax`.
+  @inlinable
+  public var isClosureShorthandParameterListSyntax: Bool {
+    self.is(ClosureShorthandParameterListSyntax.self)
+  }
+
+  /// Returns `self` as `ClosureShorthandParameterSyntax`, when possible.
+  @inlinable
+  public var asClosureShorthandParameterSyntax: ClosureShorthandParameterSyntax? {
+    self.as(ClosureShorthandParameterSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ClosureShorthandParameterSyntax`.
+  @inlinable
+  public var isClosureShorthandParameterSyntax: Bool {
+    self.is(ClosureShorthandParameterSyntax.self)
+  }
+
+  /// Returns `self` as `ClosureSignatureSyntax`, when possible.
+  @inlinable
+  public var asClosureSignatureSyntax: ClosureSignatureSyntax? {
+    self.as(ClosureSignatureSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ClosureSignatureSyntax`.
+  @inlinable
+  public var isClosureSignatureSyntax: Bool {
+    self.is(ClosureSignatureSyntax.self)
+  }
+
+  /// Returns `self` as `CodeBlockItemListSyntax`, when possible.
+  @inlinable
+  public var asCodeBlockItemListSyntax: CodeBlockItemListSyntax? {
+    self.as(CodeBlockItemListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `CodeBlockItemListSyntax`.
+  @inlinable
+  public var isCodeBlockItemListSyntax: Bool {
+    self.is(CodeBlockItemListSyntax.self)
+  }
+
+  /// Returns `self` as `CodeBlockItemSyntax`, when possible.
+  @inlinable
+  public var asCodeBlockItemSyntax: CodeBlockItemSyntax? {
+    self.as(CodeBlockItemSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `CodeBlockItemSyntax`.
+  @inlinable
+  public var isCodeBlockItemSyntax: Bool {
+    self.is(CodeBlockItemSyntax.self)
+  }
+
+  /// Returns `self` as `CodeBlockSyntax`, when possible.
+  @inlinable
+  public var asCodeBlockSyntax: CodeBlockSyntax? {
+    self.as(CodeBlockSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `CodeBlockSyntax`.
+  @inlinable
+  public var isCodeBlockSyntax: Bool {
+    self.is(CodeBlockSyntax.self)
+  }
+
+  /// Returns `self` as `CompositionTypeElementListSyntax`, when possible.
+  @inlinable
+  public var asCompositionTypeElementListSyntax: CompositionTypeElementListSyntax? {
+    self.as(CompositionTypeElementListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `CompositionTypeElementListSyntax`.
+  @inlinable
+  public var isCompositionTypeElementListSyntax: Bool {
+    self.is(CompositionTypeElementListSyntax.self)
+  }
+
+  /// Returns `self` as `CompositionTypeElementSyntax`, when possible.
+  @inlinable
+  public var asCompositionTypeElementSyntax: CompositionTypeElementSyntax? {
+    self.as(CompositionTypeElementSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `CompositionTypeElementSyntax`.
+  @inlinable
+  public var isCompositionTypeElementSyntax: Bool {
+    self.is(CompositionTypeElementSyntax.self)
+  }
+
+  /// Returns `self` as `CompositionTypeSyntax`, when possible.
+  @inlinable
+  public var asCompositionTypeSyntax: CompositionTypeSyntax? {
+    self.as(CompositionTypeSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `CompositionTypeSyntax`.
+  @inlinable
+  public var isCompositionTypeSyntax: Bool {
+    self.is(CompositionTypeSyntax.self)
+  }
+
+  /// Returns `self` as `ConditionElementListSyntax`, when possible.
+  @inlinable
+  public var asConditionElementListSyntax: ConditionElementListSyntax? {
+    self.as(ConditionElementListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ConditionElementListSyntax`.
+  @inlinable
+  public var isConditionElementListSyntax: Bool {
+    self.is(ConditionElementListSyntax.self)
+  }
+
+  /// Returns `self` as `ConditionElementSyntax`, when possible.
+  @inlinable
+  public var asConditionElementSyntax: ConditionElementSyntax? {
+    self.as(ConditionElementSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ConditionElementSyntax`.
+  @inlinable
+  public var isConditionElementSyntax: Bool {
+    self.is(ConditionElementSyntax.self)
+  }
+
+  /// Returns `self` as `ConformanceRequirementSyntax`, when possible.
+  @inlinable
+  public var asConformanceRequirementSyntax: ConformanceRequirementSyntax? {
+    self.as(ConformanceRequirementSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ConformanceRequirementSyntax`.
+  @inlinable
+  public var isConformanceRequirementSyntax: Bool {
+    self.is(ConformanceRequirementSyntax.self)
+  }
+
+  /// Returns `self` as `ConsumeExprSyntax`, when possible.
+  @inlinable
+  public var asConsumeExprSyntax: ConsumeExprSyntax? {
+    self.as(ConsumeExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ConsumeExprSyntax`.
+  @inlinable
+  public var isConsumeExprSyntax: Bool {
+    self.is(ConsumeExprSyntax.self)
+  }
+
+  /// Returns `self` as `ContinueStmtSyntax`, when possible.
+  @inlinable
+  public var asContinueStmtSyntax: ContinueStmtSyntax? {
+    self.as(ContinueStmtSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ContinueStmtSyntax`.
+  @inlinable
+  public var isContinueStmtSyntax: Bool {
+    self.is(ContinueStmtSyntax.self)
+  }
+
+  /// Returns `self` as `CopyExprSyntax`, when possible.
+  @inlinable
+  public var asCopyExprSyntax: CopyExprSyntax? {
+    self.as(CopyExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `CopyExprSyntax`.
+  @inlinable
+  public var isCopyExprSyntax: Bool {
+    self.is(CopyExprSyntax.self)
+  }
+
+  /// Returns `self` as `DeclModifierDetailSyntax`, when possible.
+  @inlinable
+  public var asDeclModifierDetailSyntax: DeclModifierDetailSyntax? {
+    self.as(DeclModifierDetailSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `DeclModifierDetailSyntax`.
+  @inlinable
+  public var isDeclModifierDetailSyntax: Bool {
+    self.is(DeclModifierDetailSyntax.self)
+  }
+
+  /// Returns `self` as `DeclModifierListSyntax`, when possible.
+  @inlinable
+  public var asDeclModifierListSyntax: DeclModifierListSyntax? {
+    self.as(DeclModifierListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `DeclModifierListSyntax`.
+  @inlinable
+  public var isDeclModifierListSyntax: Bool {
+    self.is(DeclModifierListSyntax.self)
+  }
+
+  /// Returns `self` as `DeclModifierSyntax`, when possible.
+  @inlinable
+  public var asDeclModifierSyntax: DeclModifierSyntax? {
+    self.as(DeclModifierSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `DeclModifierSyntax`.
+  @inlinable
+  public var isDeclModifierSyntax: Bool {
+    self.is(DeclModifierSyntax.self)
+  }
+
+  /// Returns `self` as `DeclNameArgumentListSyntax`, when possible.
+  @inlinable
+  public var asDeclNameArgumentListSyntax: DeclNameArgumentListSyntax? {
+    self.as(DeclNameArgumentListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `DeclNameArgumentListSyntax`.
+  @inlinable
+  public var isDeclNameArgumentListSyntax: Bool {
+    self.is(DeclNameArgumentListSyntax.self)
+  }
+
+  /// Returns `self` as `DeclNameArgumentSyntax`, when possible.
+  @inlinable
+  public var asDeclNameArgumentSyntax: DeclNameArgumentSyntax? {
+    self.as(DeclNameArgumentSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `DeclNameArgumentSyntax`.
+  @inlinable
+  public var isDeclNameArgumentSyntax: Bool {
+    self.is(DeclNameArgumentSyntax.self)
+  }
+
+  /// Returns `self` as `DeclNameArgumentsSyntax`, when possible.
+  @inlinable
+  public var asDeclNameArgumentsSyntax: DeclNameArgumentsSyntax? {
+    self.as(DeclNameArgumentsSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `DeclNameArgumentsSyntax`.
+  @inlinable
+  public var isDeclNameArgumentsSyntax: Bool {
+    self.is(DeclNameArgumentsSyntax.self)
+  }
+
+  /// Returns `self` as `DeclReferenceExprSyntax`, when possible.
+  @inlinable
+  public var asDeclReferenceExprSyntax: DeclReferenceExprSyntax? {
+    self.as(DeclReferenceExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `DeclReferenceExprSyntax`.
+  @inlinable
+  public var isDeclReferenceExprSyntax: Bool {
+    self.is(DeclReferenceExprSyntax.self)
+  }
+
+  /// Returns `self` as `DeclSyntax`, when possible.
+  @inlinable
+  public var asDeclSyntax: DeclSyntax? {
+    self.as(DeclSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `DeclSyntax`.
+  @inlinable
+  public var isDeclSyntax: Bool {
+    self.is(DeclSyntax.self)
+  }
+
+  /// Returns `self` as `DeferStmtSyntax`, when possible.
+  @inlinable
+  public var asDeferStmtSyntax: DeferStmtSyntax? {
+    self.as(DeferStmtSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `DeferStmtSyntax`.
+  @inlinable
+  public var isDeferStmtSyntax: Bool {
+    self.is(DeferStmtSyntax.self)
+  }
+
+  /// Returns `self` as `DeinitializerDeclSyntax`, when possible.
+  @inlinable
+  public var asDeinitializerDeclSyntax: DeinitializerDeclSyntax? {
+    self.as(DeinitializerDeclSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `DeinitializerDeclSyntax`.
+  @inlinable
+  public var isDeinitializerDeclSyntax: Bool {
+    self.is(DeinitializerDeclSyntax.self)
+  }
+
+  /// Returns `self` as `DeinitializerEffectSpecifiersSyntax`, when possible.
+  @inlinable
+  public var asDeinitializerEffectSpecifiersSyntax: DeinitializerEffectSpecifiersSyntax? {
+    self.as(DeinitializerEffectSpecifiersSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `DeinitializerEffectSpecifiersSyntax`.
+  @inlinable
+  public var isDeinitializerEffectSpecifiersSyntax: Bool {
+    self.is(DeinitializerEffectSpecifiersSyntax.self)
+  }
+
+  /// Returns `self` as `DerivativeAttributeArgumentsSyntax`, when possible.
+  @inlinable
+  public var asDerivativeAttributeArgumentsSyntax: DerivativeAttributeArgumentsSyntax? {
+    self.as(DerivativeAttributeArgumentsSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `DerivativeAttributeArgumentsSyntax`.
+  @inlinable
+  public var isDerivativeAttributeArgumentsSyntax: Bool {
+    self.is(DerivativeAttributeArgumentsSyntax.self)
+  }
+
+  /// Returns `self` as `DesignatedTypeListSyntax`, when possible.
+  @inlinable
+  public var asDesignatedTypeListSyntax: DesignatedTypeListSyntax? {
+    self.as(DesignatedTypeListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `DesignatedTypeListSyntax`.
+  @inlinable
+  public var isDesignatedTypeListSyntax: Bool {
+    self.is(DesignatedTypeListSyntax.self)
+  }
+
+  /// Returns `self` as `DesignatedTypeSyntax`, when possible.
+  @inlinable
+  public var asDesignatedTypeSyntax: DesignatedTypeSyntax? {
+    self.as(DesignatedTypeSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `DesignatedTypeSyntax`.
+  @inlinable
+  public var isDesignatedTypeSyntax: Bool {
+    self.is(DesignatedTypeSyntax.self)
+  }
+
+  /// Returns `self` as `DictionaryElementListSyntax`, when possible.
+  @inlinable
+  public var asDictionaryElementListSyntax: DictionaryElementListSyntax? {
+    self.as(DictionaryElementListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `DictionaryElementListSyntax`.
+  @inlinable
+  public var isDictionaryElementListSyntax: Bool {
+    self.is(DictionaryElementListSyntax.self)
+  }
+
+  /// Returns `self` as `DictionaryElementSyntax`, when possible.
+  @inlinable
+  public var asDictionaryElementSyntax: DictionaryElementSyntax? {
+    self.as(DictionaryElementSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `DictionaryElementSyntax`.
+  @inlinable
+  public var isDictionaryElementSyntax: Bool {
+    self.is(DictionaryElementSyntax.self)
+  }
+
+  /// Returns `self` as `DictionaryExprSyntax`, when possible.
+  @inlinable
+  public var asDictionaryExprSyntax: DictionaryExprSyntax? {
+    self.as(DictionaryExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `DictionaryExprSyntax`.
+  @inlinable
+  public var isDictionaryExprSyntax: Bool {
+    self.is(DictionaryExprSyntax.self)
+  }
+
+  /// Returns `self` as `DictionaryTypeSyntax`, when possible.
+  @inlinable
+  public var asDictionaryTypeSyntax: DictionaryTypeSyntax? {
+    self.as(DictionaryTypeSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `DictionaryTypeSyntax`.
+  @inlinable
+  public var isDictionaryTypeSyntax: Bool {
+    self.is(DictionaryTypeSyntax.self)
+  }
+
+  /// Returns `self` as `DifferentiabilityArgumentListSyntax`, when possible.
+  @inlinable
+  public var asDifferentiabilityArgumentListSyntax: DifferentiabilityArgumentListSyntax? {
+    self.as(DifferentiabilityArgumentListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `DifferentiabilityArgumentListSyntax`.
+  @inlinable
+  public var isDifferentiabilityArgumentListSyntax: Bool {
+    self.is(DifferentiabilityArgumentListSyntax.self)
+  }
+
+  /// Returns `self` as `DifferentiabilityArgumentSyntax`, when possible.
+  @inlinable
+  public var asDifferentiabilityArgumentSyntax: DifferentiabilityArgumentSyntax? {
+    self.as(DifferentiabilityArgumentSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `DifferentiabilityArgumentSyntax`.
+  @inlinable
+  public var isDifferentiabilityArgumentSyntax: Bool {
+    self.is(DifferentiabilityArgumentSyntax.self)
+  }
+
+  /// Returns `self` as `DifferentiabilityArgumentsSyntax`, when possible.
+  @inlinable
+  public var asDifferentiabilityArgumentsSyntax: DifferentiabilityArgumentsSyntax? {
+    self.as(DifferentiabilityArgumentsSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `DifferentiabilityArgumentsSyntax`.
+  @inlinable
+  public var isDifferentiabilityArgumentsSyntax: Bool {
+    self.is(DifferentiabilityArgumentsSyntax.self)
+  }
+
+  /// Returns `self` as `DifferentiabilityWithRespectToArgumentSyntax`, when possible.
+  @inlinable
+  public var asDifferentiabilityWithRespectToArgumentSyntax: DifferentiabilityWithRespectToArgumentSyntax? {
+    self.as(DifferentiabilityWithRespectToArgumentSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `DifferentiabilityWithRespectToArgumentSyntax`.
+  @inlinable
+  public var isDifferentiabilityWithRespectToArgumentSyntax: Bool {
+    self.is(DifferentiabilityWithRespectToArgumentSyntax.self)
+  }
+
+  /// Returns `self` as `DifferentiableAttributeArgumentsSyntax`, when possible.
+  @inlinable
+  public var asDifferentiableAttributeArgumentsSyntax: DifferentiableAttributeArgumentsSyntax? {
+    self.as(DifferentiableAttributeArgumentsSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `DifferentiableAttributeArgumentsSyntax`.
+  @inlinable
+  public var isDifferentiableAttributeArgumentsSyntax: Bool {
+    self.is(DifferentiableAttributeArgumentsSyntax.self)
+  }
+
+  /// Returns `self` as `DiscardAssignmentExprSyntax`, when possible.
+  @inlinable
+  public var asDiscardAssignmentExprSyntax: DiscardAssignmentExprSyntax? {
+    self.as(DiscardAssignmentExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `DiscardAssignmentExprSyntax`.
+  @inlinable
+  public var isDiscardAssignmentExprSyntax: Bool {
+    self.is(DiscardAssignmentExprSyntax.self)
+  }
+
+  /// Returns `self` as `DiscardStmtSyntax`, when possible.
+  @inlinable
+  public var asDiscardStmtSyntax: DiscardStmtSyntax? {
+    self.as(DiscardStmtSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `DiscardStmtSyntax`.
+  @inlinable
+  public var isDiscardStmtSyntax: Bool {
+    self.is(DiscardStmtSyntax.self)
+  }
+
+  /// Returns `self` as `DoStmtSyntax`, when possible.
+  @inlinable
+  public var asDoStmtSyntax: DoStmtSyntax? {
+    self.as(DoStmtSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `DoStmtSyntax`.
+  @inlinable
+  public var isDoStmtSyntax: Bool {
+    self.is(DoStmtSyntax.self)
+  }
+
+  /// Returns `self` as `DocumentationAttributeArgumentListSyntax`, when possible.
+  @inlinable
+  public var asDocumentationAttributeArgumentListSyntax: DocumentationAttributeArgumentListSyntax? {
+    self.as(DocumentationAttributeArgumentListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `DocumentationAttributeArgumentListSyntax`.
+  @inlinable
+  public var isDocumentationAttributeArgumentListSyntax: Bool {
+    self.is(DocumentationAttributeArgumentListSyntax.self)
+  }
+
+  /// Returns `self` as `DocumentationAttributeArgumentSyntax`, when possible.
+  @inlinable
+  public var asDocumentationAttributeArgumentSyntax: DocumentationAttributeArgumentSyntax? {
+    self.as(DocumentationAttributeArgumentSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `DocumentationAttributeArgumentSyntax`.
+  @inlinable
+  public var isDocumentationAttributeArgumentSyntax: Bool {
+    self.is(DocumentationAttributeArgumentSyntax.self)
+  }
+
+  /// Returns `self` as `DynamicReplacementAttributeArgumentsSyntax`, when possible.
+  @inlinable
+  public var asDynamicReplacementAttributeArgumentsSyntax: DynamicReplacementAttributeArgumentsSyntax? {
+    self.as(DynamicReplacementAttributeArgumentsSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `DynamicReplacementAttributeArgumentsSyntax`.
+  @inlinable
+  public var isDynamicReplacementAttributeArgumentsSyntax: Bool {
+    self.is(DynamicReplacementAttributeArgumentsSyntax.self)
+  }
+
+  /// Returns `self` as `EditorPlaceholderDeclSyntax`, when possible.
+  @inlinable
+  public var asEditorPlaceholderDeclSyntax: EditorPlaceholderDeclSyntax? {
+    self.as(EditorPlaceholderDeclSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `EditorPlaceholderDeclSyntax`.
+  @inlinable
+  public var isEditorPlaceholderDeclSyntax: Bool {
+    self.is(EditorPlaceholderDeclSyntax.self)
+  }
+
+  /// Returns `self` as `EditorPlaceholderExprSyntax`, when possible.
+  @inlinable
+  public var asEditorPlaceholderExprSyntax: EditorPlaceholderExprSyntax? {
+    self.as(EditorPlaceholderExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `EditorPlaceholderExprSyntax`.
+  @inlinable
+  public var isEditorPlaceholderExprSyntax: Bool {
+    self.is(EditorPlaceholderExprSyntax.self)
+  }
+
+  /// Returns `self` as `EffectsAttributeArgumentListSyntax`, when possible.
+  @inlinable
+  public var asEffectsAttributeArgumentListSyntax: EffectsAttributeArgumentListSyntax? {
+    self.as(EffectsAttributeArgumentListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `EffectsAttributeArgumentListSyntax`.
+  @inlinable
+  public var isEffectsAttributeArgumentListSyntax: Bool {
+    self.is(EffectsAttributeArgumentListSyntax.self)
+  }
+
+  /// Returns `self` as `EnumCaseDeclSyntax`, when possible.
+  @inlinable
+  public var asEnumCaseDeclSyntax: EnumCaseDeclSyntax? {
+    self.as(EnumCaseDeclSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `EnumCaseDeclSyntax`.
+  @inlinable
+  public var isEnumCaseDeclSyntax: Bool {
+    self.is(EnumCaseDeclSyntax.self)
+  }
+
+  /// Returns `self` as `EnumCaseElementListSyntax`, when possible.
+  @inlinable
+  public var asEnumCaseElementListSyntax: EnumCaseElementListSyntax? {
+    self.as(EnumCaseElementListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `EnumCaseElementListSyntax`.
+  @inlinable
+  public var isEnumCaseElementListSyntax: Bool {
+    self.is(EnumCaseElementListSyntax.self)
+  }
+
+  /// Returns `self` as `EnumCaseElementSyntax`, when possible.
+  @inlinable
+  public var asEnumCaseElementSyntax: EnumCaseElementSyntax? {
+    self.as(EnumCaseElementSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `EnumCaseElementSyntax`.
+  @inlinable
+  public var isEnumCaseElementSyntax: Bool {
+    self.is(EnumCaseElementSyntax.self)
+  }
+
+  /// Returns `self` as `EnumCaseParameterClauseSyntax`, when possible.
+  @inlinable
+  public var asEnumCaseParameterClauseSyntax: EnumCaseParameterClauseSyntax? {
+    self.as(EnumCaseParameterClauseSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `EnumCaseParameterClauseSyntax`.
+  @inlinable
+  public var isEnumCaseParameterClauseSyntax: Bool {
+    self.is(EnumCaseParameterClauseSyntax.self)
+  }
+
+  /// Returns `self` as `EnumCaseParameterListSyntax`, when possible.
+  @inlinable
+  public var asEnumCaseParameterListSyntax: EnumCaseParameterListSyntax? {
+    self.as(EnumCaseParameterListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `EnumCaseParameterListSyntax`.
+  @inlinable
+  public var isEnumCaseParameterListSyntax: Bool {
+    self.is(EnumCaseParameterListSyntax.self)
+  }
+
+  /// Returns `self` as `EnumCaseParameterSyntax`, when possible.
+  @inlinable
+  public var asEnumCaseParameterSyntax: EnumCaseParameterSyntax? {
+    self.as(EnumCaseParameterSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `EnumCaseParameterSyntax`.
+  @inlinable
+  public var isEnumCaseParameterSyntax: Bool {
+    self.is(EnumCaseParameterSyntax.self)
+  }
+
+  /// Returns `self` as `EnumDeclSyntax`, when possible.
+  @inlinable
+  public var asEnumDeclSyntax: EnumDeclSyntax? {
+    self.as(EnumDeclSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `EnumDeclSyntax`.
+  @inlinable
+  public var isEnumDeclSyntax: Bool {
+    self.is(EnumDeclSyntax.self)
+  }
+
+  /// Returns `self` as `ExprListSyntax`, when possible.
+  @inlinable
+  public var asExprListSyntax: ExprListSyntax? {
+    self.as(ExprListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ExprListSyntax`.
+  @inlinable
+  public var isExprListSyntax: Bool {
+    self.is(ExprListSyntax.self)
+  }
+
+  /// Returns `self` as `ExprSyntax`, when possible.
+  @inlinable
+  public var asExprSyntax: ExprSyntax? {
+    self.as(ExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ExprSyntax`.
+  @inlinable
+  public var isExprSyntax: Bool {
+    self.is(ExprSyntax.self)
+  }
+
+  /// Returns `self` as `ExpressionPatternSyntax`, when possible.
+  @inlinable
+  public var asExpressionPatternSyntax: ExpressionPatternSyntax? {
+    self.as(ExpressionPatternSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ExpressionPatternSyntax`.
+  @inlinable
+  public var isExpressionPatternSyntax: Bool {
+    self.is(ExpressionPatternSyntax.self)
+  }
+
+  /// Returns `self` as `ExpressionSegmentSyntax`, when possible.
+  @inlinable
+  public var asExpressionSegmentSyntax: ExpressionSegmentSyntax? {
+    self.as(ExpressionSegmentSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ExpressionSegmentSyntax`.
+  @inlinable
+  public var isExpressionSegmentSyntax: Bool {
+    self.is(ExpressionSegmentSyntax.self)
+  }
+
+  /// Returns `self` as `ExpressionStmtSyntax`, when possible.
+  @inlinable
+  public var asExpressionStmtSyntax: ExpressionStmtSyntax? {
+    self.as(ExpressionStmtSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ExpressionStmtSyntax`.
+  @inlinable
+  public var isExpressionStmtSyntax: Bool {
+    self.is(ExpressionStmtSyntax.self)
+  }
+
+  /// Returns `self` as `ExtensionDeclSyntax`, when possible.
+  @inlinable
+  public var asExtensionDeclSyntax: ExtensionDeclSyntax? {
+    self.as(ExtensionDeclSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ExtensionDeclSyntax`.
+  @inlinable
+  public var isExtensionDeclSyntax: Bool {
+    self.is(ExtensionDeclSyntax.self)
+  }
+
+  /// Returns `self` as `FallThroughStmtSyntax`, when possible.
+  @inlinable
+  public var asFallThroughStmtSyntax: FallThroughStmtSyntax? {
+    self.as(FallThroughStmtSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `FallThroughStmtSyntax`.
+  @inlinable
+  public var isFallThroughStmtSyntax: Bool {
+    self.is(FallThroughStmtSyntax.self)
+  }
+
+  /// Returns `self` as `FloatLiteralExprSyntax`, when possible.
+  @inlinable
+  public var asFloatLiteralExprSyntax: FloatLiteralExprSyntax? {
+    self.as(FloatLiteralExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `FloatLiteralExprSyntax`.
+  @inlinable
+  public var isFloatLiteralExprSyntax: Bool {
+    self.is(FloatLiteralExprSyntax.self)
+  }
+
+  /// Returns `self` as `ForStmtSyntax`, when possible.
+  @inlinable
+  public var asForStmtSyntax: ForStmtSyntax? {
+    self.as(ForStmtSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ForStmtSyntax`.
+  @inlinable
+  public var isForStmtSyntax: Bool {
+    self.is(ForStmtSyntax.self)
+  }
+
+  /// Returns `self` as `ForceUnwrapExprSyntax`, when possible.
+  @inlinable
+  public var asForceUnwrapExprSyntax: ForceUnwrapExprSyntax? {
+    self.as(ForceUnwrapExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ForceUnwrapExprSyntax`.
+  @inlinable
+  public var isForceUnwrapExprSyntax: Bool {
+    self.is(ForceUnwrapExprSyntax.self)
+  }
+
+  /// Returns `self` as `FunctionCallExprSyntax`, when possible.
+  @inlinable
+  public var asFunctionCallExprSyntax: FunctionCallExprSyntax? {
+    self.as(FunctionCallExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `FunctionCallExprSyntax`.
+  @inlinable
+  public var isFunctionCallExprSyntax: Bool {
+    self.is(FunctionCallExprSyntax.self)
+  }
+
+  /// Returns `self` as `FunctionDeclSyntax`, when possible.
+  @inlinable
+  public var asFunctionDeclSyntax: FunctionDeclSyntax? {
+    self.as(FunctionDeclSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `FunctionDeclSyntax`.
+  @inlinable
+  public var isFunctionDeclSyntax: Bool {
+    self.is(FunctionDeclSyntax.self)
+  }
+
+  /// Returns `self` as `FunctionEffectSpecifiersSyntax`, when possible.
+  @inlinable
+  public var asFunctionEffectSpecifiersSyntax: FunctionEffectSpecifiersSyntax? {
+    self.as(FunctionEffectSpecifiersSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `FunctionEffectSpecifiersSyntax`.
+  @inlinable
+  public var isFunctionEffectSpecifiersSyntax: Bool {
+    self.is(FunctionEffectSpecifiersSyntax.self)
+  }
+
+  /// Returns `self` as `FunctionParameterClauseSyntax`, when possible.
+  @inlinable
+  public var asFunctionParameterClauseSyntax: FunctionParameterClauseSyntax? {
+    self.as(FunctionParameterClauseSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `FunctionParameterClauseSyntax`.
+  @inlinable
+  public var isFunctionParameterClauseSyntax: Bool {
+    self.is(FunctionParameterClauseSyntax.self)
+  }
+
+  /// Returns `self` as `FunctionParameterListSyntax`, when possible.
+  @inlinable
+  public var asFunctionParameterListSyntax: FunctionParameterListSyntax? {
+    self.as(FunctionParameterListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `FunctionParameterListSyntax`.
+  @inlinable
+  public var isFunctionParameterListSyntax: Bool {
+    self.is(FunctionParameterListSyntax.self)
+  }
+
+  /// Returns `self` as `FunctionParameterSyntax`, when possible.
+  @inlinable
+  public var asFunctionParameterSyntax: FunctionParameterSyntax? {
+    self.as(FunctionParameterSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `FunctionParameterSyntax`.
+  @inlinable
+  public var isFunctionParameterSyntax: Bool {
+    self.is(FunctionParameterSyntax.self)
+  }
+
+  /// Returns `self` as `FunctionSignatureSyntax`, when possible.
+  @inlinable
+  public var asFunctionSignatureSyntax: FunctionSignatureSyntax? {
+    self.as(FunctionSignatureSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `FunctionSignatureSyntax`.
+  @inlinable
+  public var isFunctionSignatureSyntax: Bool {
+    self.is(FunctionSignatureSyntax.self)
+  }
+
+  /// Returns `self` as `FunctionTypeSyntax`, when possible.
+  @inlinable
+  public var asFunctionTypeSyntax: FunctionTypeSyntax? {
+    self.as(FunctionTypeSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `FunctionTypeSyntax`.
+  @inlinable
+  public var isFunctionTypeSyntax: Bool {
+    self.is(FunctionTypeSyntax.self)
+  }
+
+  /// Returns `self` as `GenericArgumentClauseSyntax`, when possible.
+  @inlinable
+  public var asGenericArgumentClauseSyntax: GenericArgumentClauseSyntax? {
+    self.as(GenericArgumentClauseSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `GenericArgumentClauseSyntax`.
+  @inlinable
+  public var isGenericArgumentClauseSyntax: Bool {
+    self.is(GenericArgumentClauseSyntax.self)
+  }
+
+  /// Returns `self` as `GenericArgumentListSyntax`, when possible.
+  @inlinable
+  public var asGenericArgumentListSyntax: GenericArgumentListSyntax? {
+    self.as(GenericArgumentListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `GenericArgumentListSyntax`.
+  @inlinable
+  public var isGenericArgumentListSyntax: Bool {
+    self.is(GenericArgumentListSyntax.self)
+  }
+
+  /// Returns `self` as `GenericArgumentSyntax`, when possible.
+  @inlinable
+  public var asGenericArgumentSyntax: GenericArgumentSyntax? {
+    self.as(GenericArgumentSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `GenericArgumentSyntax`.
+  @inlinable
+  public var isGenericArgumentSyntax: Bool {
+    self.is(GenericArgumentSyntax.self)
+  }
+
+  /// Returns `self` as `GenericParameterClauseSyntax`, when possible.
+  @inlinable
+  public var asGenericParameterClauseSyntax: GenericParameterClauseSyntax? {
+    self.as(GenericParameterClauseSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `GenericParameterClauseSyntax`.
+  @inlinable
+  public var isGenericParameterClauseSyntax: Bool {
+    self.is(GenericParameterClauseSyntax.self)
+  }
+
+  /// Returns `self` as `GenericParameterListSyntax`, when possible.
+  @inlinable
+  public var asGenericParameterListSyntax: GenericParameterListSyntax? {
+    self.as(GenericParameterListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `GenericParameterListSyntax`.
+  @inlinable
+  public var isGenericParameterListSyntax: Bool {
+    self.is(GenericParameterListSyntax.self)
+  }
+
+  /// Returns `self` as `GenericParameterSyntax`, when possible.
+  @inlinable
+  public var asGenericParameterSyntax: GenericParameterSyntax? {
+    self.as(GenericParameterSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `GenericParameterSyntax`.
+  @inlinable
+  public var isGenericParameterSyntax: Bool {
+    self.is(GenericParameterSyntax.self)
+  }
+
+  /// Returns `self` as `GenericRequirementListSyntax`, when possible.
+  @inlinable
+  public var asGenericRequirementListSyntax: GenericRequirementListSyntax? {
+    self.as(GenericRequirementListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `GenericRequirementListSyntax`.
+  @inlinable
+  public var isGenericRequirementListSyntax: Bool {
+    self.is(GenericRequirementListSyntax.self)
+  }
+
+  /// Returns `self` as `GenericRequirementSyntax`, when possible.
+  @inlinable
+  public var asGenericRequirementSyntax: GenericRequirementSyntax? {
+    self.as(GenericRequirementSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `GenericRequirementSyntax`.
+  @inlinable
+  public var isGenericRequirementSyntax: Bool {
+    self.is(GenericRequirementSyntax.self)
+  }
+
+  /// Returns `self` as `GenericSpecializationExprSyntax`, when possible.
+  @inlinable
+  public var asGenericSpecializationExprSyntax: GenericSpecializationExprSyntax? {
+    self.as(GenericSpecializationExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `GenericSpecializationExprSyntax`.
+  @inlinable
+  public var isGenericSpecializationExprSyntax: Bool {
+    self.is(GenericSpecializationExprSyntax.self)
+  }
+
+  /// Returns `self` as `GenericWhereClauseSyntax`, when possible.
+  @inlinable
+  public var asGenericWhereClauseSyntax: GenericWhereClauseSyntax? {
+    self.as(GenericWhereClauseSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `GenericWhereClauseSyntax`.
+  @inlinable
+  public var isGenericWhereClauseSyntax: Bool {
+    self.is(GenericWhereClauseSyntax.self)
+  }
+
+  /// Returns `self` as `GuardStmtSyntax`, when possible.
+  @inlinable
+  public var asGuardStmtSyntax: GuardStmtSyntax? {
+    self.as(GuardStmtSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `GuardStmtSyntax`.
+  @inlinable
+  public var isGuardStmtSyntax: Bool {
+    self.is(GuardStmtSyntax.self)
+  }
+
+  /// Returns `self` as `IdentifierPatternSyntax`, when possible.
+  @inlinable
+  public var asIdentifierPatternSyntax: IdentifierPatternSyntax? {
+    self.as(IdentifierPatternSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `IdentifierPatternSyntax`.
+  @inlinable
+  public var isIdentifierPatternSyntax: Bool {
+    self.is(IdentifierPatternSyntax.self)
+  }
+
+  /// Returns `self` as `IdentifierTypeSyntax`, when possible.
+  @inlinable
+  public var asIdentifierTypeSyntax: IdentifierTypeSyntax? {
+    self.as(IdentifierTypeSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `IdentifierTypeSyntax`.
+  @inlinable
+  public var isIdentifierTypeSyntax: Bool {
+    self.is(IdentifierTypeSyntax.self)
+  }
+
+  /// Returns `self` as `IfConfigClauseListSyntax`, when possible.
+  @inlinable
+  public var asIfConfigClauseListSyntax: IfConfigClauseListSyntax? {
+    self.as(IfConfigClauseListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `IfConfigClauseListSyntax`.
+  @inlinable
+  public var isIfConfigClauseListSyntax: Bool {
+    self.is(IfConfigClauseListSyntax.self)
+  }
+
+  /// Returns `self` as `IfConfigClauseSyntax`, when possible.
+  @inlinable
+  public var asIfConfigClauseSyntax: IfConfigClauseSyntax? {
+    self.as(IfConfigClauseSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `IfConfigClauseSyntax`.
+  @inlinable
+  public var isIfConfigClauseSyntax: Bool {
+    self.is(IfConfigClauseSyntax.self)
+  }
+
+  /// Returns `self` as `IfConfigDeclSyntax`, when possible.
+  @inlinable
+  public var asIfConfigDeclSyntax: IfConfigDeclSyntax? {
+    self.as(IfConfigDeclSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `IfConfigDeclSyntax`.
+  @inlinable
+  public var isIfConfigDeclSyntax: Bool {
+    self.is(IfConfigDeclSyntax.self)
+  }
+
+  /// Returns `self` as `IfExprSyntax`, when possible.
+  @inlinable
+  public var asIfExprSyntax: IfExprSyntax? {
+    self.as(IfExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `IfExprSyntax`.
+  @inlinable
+  public var isIfExprSyntax: Bool {
+    self.is(IfExprSyntax.self)
+  }
+
+  /// Returns `self` as `ImplementsAttributeArgumentsSyntax`, when possible.
+  @inlinable
+  public var asImplementsAttributeArgumentsSyntax: ImplementsAttributeArgumentsSyntax? {
+    self.as(ImplementsAttributeArgumentsSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ImplementsAttributeArgumentsSyntax`.
+  @inlinable
+  public var isImplementsAttributeArgumentsSyntax: Bool {
+    self.is(ImplementsAttributeArgumentsSyntax.self)
+  }
+
+  /// Returns `self` as `ImplicitlyUnwrappedOptionalTypeSyntax`, when possible.
+  @inlinable
+  public var asImplicitlyUnwrappedOptionalTypeSyntax: ImplicitlyUnwrappedOptionalTypeSyntax? {
+    self.as(ImplicitlyUnwrappedOptionalTypeSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ImplicitlyUnwrappedOptionalTypeSyntax`.
+  @inlinable
+  public var isImplicitlyUnwrappedOptionalTypeSyntax: Bool {
+    self.is(ImplicitlyUnwrappedOptionalTypeSyntax.self)
+  }
+
+  /// Returns `self` as `ImportDeclSyntax`, when possible.
+  @inlinable
+  public var asImportDeclSyntax: ImportDeclSyntax? {
+    self.as(ImportDeclSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ImportDeclSyntax`.
+  @inlinable
+  public var isImportDeclSyntax: Bool {
+    self.is(ImportDeclSyntax.self)
+  }
+
+  /// Returns `self` as `ImportPathComponentListSyntax`, when possible.
+  @inlinable
+  public var asImportPathComponentListSyntax: ImportPathComponentListSyntax? {
+    self.as(ImportPathComponentListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ImportPathComponentListSyntax`.
+  @inlinable
+  public var isImportPathComponentListSyntax: Bool {
+    self.is(ImportPathComponentListSyntax.self)
+  }
+
+  /// Returns `self` as `ImportPathComponentSyntax`, when possible.
+  @inlinable
+  public var asImportPathComponentSyntax: ImportPathComponentSyntax? {
+    self.as(ImportPathComponentSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ImportPathComponentSyntax`.
+  @inlinable
+  public var isImportPathComponentSyntax: Bool {
+    self.is(ImportPathComponentSyntax.self)
+  }
+
+  /// Returns `self` as `InOutExprSyntax`, when possible.
+  @inlinable
+  public var asInOutExprSyntax: InOutExprSyntax? {
+    self.as(InOutExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `InOutExprSyntax`.
+  @inlinable
+  public var isInOutExprSyntax: Bool {
+    self.is(InOutExprSyntax.self)
+  }
+
+  /// Returns `self` as `InfixOperatorExprSyntax`, when possible.
+  @inlinable
+  public var asInfixOperatorExprSyntax: InfixOperatorExprSyntax? {
+    self.as(InfixOperatorExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `InfixOperatorExprSyntax`.
+  @inlinable
+  public var isInfixOperatorExprSyntax: Bool {
+    self.is(InfixOperatorExprSyntax.self)
+  }
+
+  /// Returns `self` as `InheritanceClauseSyntax`, when possible.
+  @inlinable
+  public var asInheritanceClauseSyntax: InheritanceClauseSyntax? {
+    self.as(InheritanceClauseSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `InheritanceClauseSyntax`.
+  @inlinable
+  public var isInheritanceClauseSyntax: Bool {
+    self.is(InheritanceClauseSyntax.self)
+  }
+
+  /// Returns `self` as `InheritedTypeListSyntax`, when possible.
+  @inlinable
+  public var asInheritedTypeListSyntax: InheritedTypeListSyntax? {
+    self.as(InheritedTypeListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `InheritedTypeListSyntax`.
+  @inlinable
+  public var isInheritedTypeListSyntax: Bool {
+    self.is(InheritedTypeListSyntax.self)
+  }
+
+  /// Returns `self` as `InheritedTypeSyntax`, when possible.
+  @inlinable
+  public var asInheritedTypeSyntax: InheritedTypeSyntax? {
+    self.as(InheritedTypeSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `InheritedTypeSyntax`.
+  @inlinable
+  public var isInheritedTypeSyntax: Bool {
+    self.is(InheritedTypeSyntax.self)
+  }
+
+  /// Returns `self` as `InitializerClauseSyntax`, when possible.
+  @inlinable
+  public var asInitializerClauseSyntax: InitializerClauseSyntax? {
+    self.as(InitializerClauseSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `InitializerClauseSyntax`.
+  @inlinable
+  public var isInitializerClauseSyntax: Bool {
+    self.is(InitializerClauseSyntax.self)
+  }
+
+  /// Returns `self` as `InitializerDeclSyntax`, when possible.
+  @inlinable
+  public var asInitializerDeclSyntax: InitializerDeclSyntax? {
+    self.as(InitializerDeclSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `InitializerDeclSyntax`.
+  @inlinable
+  public var isInitializerDeclSyntax: Bool {
+    self.is(InitializerDeclSyntax.self)
+  }
+
+  /// Returns `self` as `InlineArrayTypeSyntax`, when possible.
+  @inlinable
+  public var asInlineArrayTypeSyntax: InlineArrayTypeSyntax? {
+    self.as(InlineArrayTypeSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `InlineArrayTypeSyntax`.
+  @inlinable
+  public var isInlineArrayTypeSyntax: Bool {
+    self.is(InlineArrayTypeSyntax.self)
+  }
+
+  /// Returns `self` as `IntegerLiteralExprSyntax`, when possible.
+  @inlinable
+  public var asIntegerLiteralExprSyntax: IntegerLiteralExprSyntax? {
+    self.as(IntegerLiteralExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `IntegerLiteralExprSyntax`.
+  @inlinable
+  public var isIntegerLiteralExprSyntax: Bool {
+    self.is(IntegerLiteralExprSyntax.self)
+  }
+
+  /// Returns `self` as `IsExprSyntax`, when possible.
+  @inlinable
+  public var asIsExprSyntax: IsExprSyntax? {
+    self.as(IsExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `IsExprSyntax`.
+  @inlinable
+  public var isIsExprSyntax: Bool {
+    self.is(IsExprSyntax.self)
+  }
+
+  /// Returns `self` as `IsTypePatternSyntax`, when possible.
+  @inlinable
+  public var asIsTypePatternSyntax: IsTypePatternSyntax? {
+    self.as(IsTypePatternSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `IsTypePatternSyntax`.
+  @inlinable
+  public var isIsTypePatternSyntax: Bool {
+    self.is(IsTypePatternSyntax.self)
+  }
+
+  /// Returns `self` as `KeyPathComponentListSyntax`, when possible.
+  @inlinable
+  public var asKeyPathComponentListSyntax: KeyPathComponentListSyntax? {
+    self.as(KeyPathComponentListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `KeyPathComponentListSyntax`.
+  @inlinable
+  public var isKeyPathComponentListSyntax: Bool {
+    self.is(KeyPathComponentListSyntax.self)
+  }
+
+  /// Returns `self` as `KeyPathComponentSyntax`, when possible.
+  @inlinable
+  public var asKeyPathComponentSyntax: KeyPathComponentSyntax? {
+    self.as(KeyPathComponentSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `KeyPathComponentSyntax`.
+  @inlinable
+  public var isKeyPathComponentSyntax: Bool {
+    self.is(KeyPathComponentSyntax.self)
+  }
+
+  /// Returns `self` as `KeyPathExprSyntax`, when possible.
+  @inlinable
+  public var asKeyPathExprSyntax: KeyPathExprSyntax? {
+    self.as(KeyPathExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `KeyPathExprSyntax`.
+  @inlinable
+  public var isKeyPathExprSyntax: Bool {
+    self.is(KeyPathExprSyntax.self)
+  }
+
+  /// Returns `self` as `KeyPathOptionalComponentSyntax`, when possible.
+  @inlinable
+  public var asKeyPathOptionalComponentSyntax: KeyPathOptionalComponentSyntax? {
+    self.as(KeyPathOptionalComponentSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `KeyPathOptionalComponentSyntax`.
+  @inlinable
+  public var isKeyPathOptionalComponentSyntax: Bool {
+    self.is(KeyPathOptionalComponentSyntax.self)
+  }
+
+  /// Returns `self` as `KeyPathPropertyComponentSyntax`, when possible.
+  @inlinable
+  public var asKeyPathPropertyComponentSyntax: KeyPathPropertyComponentSyntax? {
+    self.as(KeyPathPropertyComponentSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `KeyPathPropertyComponentSyntax`.
+  @inlinable
+  public var isKeyPathPropertyComponentSyntax: Bool {
+    self.is(KeyPathPropertyComponentSyntax.self)
+  }
+
+  /// Returns `self` as `KeyPathSubscriptComponentSyntax`, when possible.
+  @inlinable
+  public var asKeyPathSubscriptComponentSyntax: KeyPathSubscriptComponentSyntax? {
+    self.as(KeyPathSubscriptComponentSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `KeyPathSubscriptComponentSyntax`.
+  @inlinable
+  public var isKeyPathSubscriptComponentSyntax: Bool {
+    self.is(KeyPathSubscriptComponentSyntax.self)
+  }
+
+  /// Returns `self` as `LabeledExprListSyntax`, when possible.
+  @inlinable
+  public var asLabeledExprListSyntax: LabeledExprListSyntax? {
+    self.as(LabeledExprListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `LabeledExprListSyntax`.
+  @inlinable
+  public var isLabeledExprListSyntax: Bool {
+    self.is(LabeledExprListSyntax.self)
+  }
+
+  /// Returns `self` as `LabeledExprSyntax`, when possible.
+  @inlinable
+  public var asLabeledExprSyntax: LabeledExprSyntax? {
+    self.as(LabeledExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `LabeledExprSyntax`.
+  @inlinable
+  public var isLabeledExprSyntax: Bool {
+    self.is(LabeledExprSyntax.self)
+  }
+
+  /// Returns `self` as `LabeledSpecializeArgumentSyntax`, when possible.
+  @inlinable
+  public var asLabeledSpecializeArgumentSyntax: LabeledSpecializeArgumentSyntax? {
+    self.as(LabeledSpecializeArgumentSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `LabeledSpecializeArgumentSyntax`.
+  @inlinable
+  public var isLabeledSpecializeArgumentSyntax: Bool {
+    self.is(LabeledSpecializeArgumentSyntax.self)
+  }
+
+  /// Returns `self` as `LabeledStmtSyntax`, when possible.
+  @inlinable
+  public var asLabeledStmtSyntax: LabeledStmtSyntax? {
+    self.as(LabeledStmtSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `LabeledStmtSyntax`.
+  @inlinable
+  public var isLabeledStmtSyntax: Bool {
+    self.is(LabeledStmtSyntax.self)
+  }
+
+  /// Returns `self` as `LayoutRequirementSyntax`, when possible.
+  @inlinable
+  public var asLayoutRequirementSyntax: LayoutRequirementSyntax? {
+    self.as(LayoutRequirementSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `LayoutRequirementSyntax`.
+  @inlinable
+  public var isLayoutRequirementSyntax: Bool {
+    self.is(LayoutRequirementSyntax.self)
+  }
+
+  /// Returns `self` as `MacroDeclSyntax`, when possible.
+  @inlinable
+  public var asMacroDeclSyntax: MacroDeclSyntax? {
+    self.as(MacroDeclSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `MacroDeclSyntax`.
+  @inlinable
+  public var isMacroDeclSyntax: Bool {
+    self.is(MacroDeclSyntax.self)
+  }
+
+  /// Returns `self` as `MacroExpansionDeclSyntax`, when possible.
+  @inlinable
+  public var asMacroExpansionDeclSyntax: MacroExpansionDeclSyntax? {
+    self.as(MacroExpansionDeclSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `MacroExpansionDeclSyntax`.
+  @inlinable
+  public var isMacroExpansionDeclSyntax: Bool {
+    self.is(MacroExpansionDeclSyntax.self)
+  }
+
+  /// Returns `self` as `MacroExpansionExprSyntax`, when possible.
+  @inlinable
+  public var asMacroExpansionExprSyntax: MacroExpansionExprSyntax? {
+    self.as(MacroExpansionExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `MacroExpansionExprSyntax`.
+  @inlinable
+  public var isMacroExpansionExprSyntax: Bool {
+    self.is(MacroExpansionExprSyntax.self)
+  }
+
+  /// Returns `self` as `MatchingPatternConditionSyntax`, when possible.
+  @inlinable
+  public var asMatchingPatternConditionSyntax: MatchingPatternConditionSyntax? {
+    self.as(MatchingPatternConditionSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `MatchingPatternConditionSyntax`.
+  @inlinable
+  public var isMatchingPatternConditionSyntax: Bool {
+    self.is(MatchingPatternConditionSyntax.self)
+  }
+
+  /// Returns `self` as `MemberAccessExprSyntax`, when possible.
+  @inlinable
+  public var asMemberAccessExprSyntax: MemberAccessExprSyntax? {
+    self.as(MemberAccessExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `MemberAccessExprSyntax`.
+  @inlinable
+  public var isMemberAccessExprSyntax: Bool {
+    self.is(MemberAccessExprSyntax.self)
+  }
+
+  /// Returns `self` as `MemberBlockItemListSyntax`, when possible.
+  @inlinable
+  public var asMemberBlockItemListSyntax: MemberBlockItemListSyntax? {
+    self.as(MemberBlockItemListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `MemberBlockItemListSyntax`.
+  @inlinable
+  public var isMemberBlockItemListSyntax: Bool {
+    self.is(MemberBlockItemListSyntax.self)
+  }
+
+  /// Returns `self` as `MemberBlockItemSyntax`, when possible.
+  @inlinable
+  public var asMemberBlockItemSyntax: MemberBlockItemSyntax? {
+    self.as(MemberBlockItemSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `MemberBlockItemSyntax`.
+  @inlinable
+  public var isMemberBlockItemSyntax: Bool {
+    self.is(MemberBlockItemSyntax.self)
+  }
+
+  /// Returns `self` as `MemberBlockSyntax`, when possible.
+  @inlinable
+  public var asMemberBlockSyntax: MemberBlockSyntax? {
+    self.as(MemberBlockSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `MemberBlockSyntax`.
+  @inlinable
+  public var isMemberBlockSyntax: Bool {
+    self.is(MemberBlockSyntax.self)
+  }
+
+  /// Returns `self` as `MemberTypeSyntax`, when possible.
+  @inlinable
+  public var asMemberTypeSyntax: MemberTypeSyntax? {
+    self.as(MemberTypeSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `MemberTypeSyntax`.
+  @inlinable
+  public var isMemberTypeSyntax: Bool {
+    self.is(MemberTypeSyntax.self)
+  }
+
+  /// Returns `self` as `MetatypeTypeSyntax`, when possible.
+  @inlinable
+  public var asMetatypeTypeSyntax: MetatypeTypeSyntax? {
+    self.as(MetatypeTypeSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `MetatypeTypeSyntax`.
+  @inlinable
+  public var isMetatypeTypeSyntax: Bool {
+    self.is(MetatypeTypeSyntax.self)
+  }
+
+  /// Returns `self` as `MissingDeclSyntax`, when possible.
+  @inlinable
+  public var asMissingDeclSyntax: MissingDeclSyntax? {
+    self.as(MissingDeclSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `MissingDeclSyntax`.
+  @inlinable
+  public var isMissingDeclSyntax: Bool {
+    self.is(MissingDeclSyntax.self)
+  }
+
+  /// Returns `self` as `MissingExprSyntax`, when possible.
+  @inlinable
+  public var asMissingExprSyntax: MissingExprSyntax? {
+    self.as(MissingExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `MissingExprSyntax`.
+  @inlinable
+  public var isMissingExprSyntax: Bool {
+    self.is(MissingExprSyntax.self)
+  }
+
+  /// Returns `self` as `MissingPatternSyntax`, when possible.
+  @inlinable
+  public var asMissingPatternSyntax: MissingPatternSyntax? {
+    self.as(MissingPatternSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `MissingPatternSyntax`.
+  @inlinable
+  public var isMissingPatternSyntax: Bool {
+    self.is(MissingPatternSyntax.self)
+  }
+
+  /// Returns `self` as `MissingStmtSyntax`, when possible.
+  @inlinable
+  public var asMissingStmtSyntax: MissingStmtSyntax? {
+    self.as(MissingStmtSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `MissingStmtSyntax`.
+  @inlinable
+  public var isMissingStmtSyntax: Bool {
+    self.is(MissingStmtSyntax.self)
+  }
+
+  /// Returns `self` as `MissingSyntax`, when possible.
+  @inlinable
+  public var asMissingSyntax: MissingSyntax? {
+    self.as(MissingSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `MissingSyntax`.
+  @inlinable
+  public var isMissingSyntax: Bool {
+    self.is(MissingSyntax.self)
+  }
+
+  /// Returns `self` as `MissingTypeSyntax`, when possible.
+  @inlinable
+  public var asMissingTypeSyntax: MissingTypeSyntax? {
+    self.as(MissingTypeSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `MissingTypeSyntax`.
+  @inlinable
+  public var isMissingTypeSyntax: Bool {
+    self.is(MissingTypeSyntax.self)
+  }
+
+  /// Returns `self` as `MultipleTrailingClosureElementListSyntax`, when possible.
+  @inlinable
+  public var asMultipleTrailingClosureElementListSyntax: MultipleTrailingClosureElementListSyntax? {
+    self.as(MultipleTrailingClosureElementListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `MultipleTrailingClosureElementListSyntax`.
+  @inlinable
+  public var isMultipleTrailingClosureElementListSyntax: Bool {
+    self.is(MultipleTrailingClosureElementListSyntax.self)
+  }
+
+  /// Returns `self` as `MultipleTrailingClosureElementSyntax`, when possible.
+  @inlinable
+  public var asMultipleTrailingClosureElementSyntax: MultipleTrailingClosureElementSyntax? {
+    self.as(MultipleTrailingClosureElementSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `MultipleTrailingClosureElementSyntax`.
+  @inlinable
+  public var isMultipleTrailingClosureElementSyntax: Bool {
+    self.is(MultipleTrailingClosureElementSyntax.self)
+  }
+
+  /// Returns `self` as `NamedOpaqueReturnTypeSyntax`, when possible.
+  @inlinable
+  public var asNamedOpaqueReturnTypeSyntax: NamedOpaqueReturnTypeSyntax? {
+    self.as(NamedOpaqueReturnTypeSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `NamedOpaqueReturnTypeSyntax`.
+  @inlinable
+  public var isNamedOpaqueReturnTypeSyntax: Bool {
+    self.is(NamedOpaqueReturnTypeSyntax.self)
+  }
+
+  /// Returns `self` as `NilLiteralExprSyntax`, when possible.
+  @inlinable
+  public var asNilLiteralExprSyntax: NilLiteralExprSyntax? {
+    self.as(NilLiteralExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `NilLiteralExprSyntax`.
+  @inlinable
+  public var isNilLiteralExprSyntax: Bool {
+    self.is(NilLiteralExprSyntax.self)
+  }
+
+  /// Returns `self` as `NonisolatedSpecifierArgumentSyntax`, when possible.
+  @inlinable
+  public var asNonisolatedSpecifierArgumentSyntax: NonisolatedSpecifierArgumentSyntax? {
+    self.as(NonisolatedSpecifierArgumentSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `NonisolatedSpecifierArgumentSyntax`.
+  @inlinable
+  public var isNonisolatedSpecifierArgumentSyntax: Bool {
+    self.is(NonisolatedSpecifierArgumentSyntax.self)
+  }
+
+  /// Returns `self` as `NonisolatedTypeSpecifierSyntax`, when possible.
+  @inlinable
+  public var asNonisolatedTypeSpecifierSyntax: NonisolatedTypeSpecifierSyntax? {
+    self.as(NonisolatedTypeSpecifierSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `NonisolatedTypeSpecifierSyntax`.
+  @inlinable
+  public var isNonisolatedTypeSpecifierSyntax: Bool {
+    self.is(NonisolatedTypeSpecifierSyntax.self)
+  }
+
+  /// Returns `self` as `ObjCSelectorPieceListSyntax`, when possible.
+  @inlinable
+  public var asObjCSelectorPieceListSyntax: ObjCSelectorPieceListSyntax? {
+    self.as(ObjCSelectorPieceListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ObjCSelectorPieceListSyntax`.
+  @inlinable
+  public var isObjCSelectorPieceListSyntax: Bool {
+    self.is(ObjCSelectorPieceListSyntax.self)
+  }
+
+  /// Returns `self` as `ObjCSelectorPieceSyntax`, when possible.
+  @inlinable
+  public var asObjCSelectorPieceSyntax: ObjCSelectorPieceSyntax? {
+    self.as(ObjCSelectorPieceSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ObjCSelectorPieceSyntax`.
+  @inlinable
+  public var isObjCSelectorPieceSyntax: Bool {
+    self.is(ObjCSelectorPieceSyntax.self)
+  }
+
+  /// Returns `self` as `OperatorDeclSyntax`, when possible.
+  @inlinable
+  public var asOperatorDeclSyntax: OperatorDeclSyntax? {
+    self.as(OperatorDeclSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `OperatorDeclSyntax`.
+  @inlinable
+  public var isOperatorDeclSyntax: Bool {
+    self.is(OperatorDeclSyntax.self)
+  }
+
+  /// Returns `self` as `OperatorPrecedenceAndTypesSyntax`, when possible.
+  @inlinable
+  public var asOperatorPrecedenceAndTypesSyntax: OperatorPrecedenceAndTypesSyntax? {
+    self.as(OperatorPrecedenceAndTypesSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `OperatorPrecedenceAndTypesSyntax`.
+  @inlinable
+  public var isOperatorPrecedenceAndTypesSyntax: Bool {
+    self.is(OperatorPrecedenceAndTypesSyntax.self)
+  }
+
+  /// Returns `self` as `OptionalBindingConditionSyntax`, when possible.
+  @inlinable
+  public var asOptionalBindingConditionSyntax: OptionalBindingConditionSyntax? {
+    self.as(OptionalBindingConditionSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `OptionalBindingConditionSyntax`.
+  @inlinable
+  public var isOptionalBindingConditionSyntax: Bool {
+    self.is(OptionalBindingConditionSyntax.self)
+  }
+
+  /// Returns `self` as `OptionalChainingExprSyntax`, when possible.
+  @inlinable
+  public var asOptionalChainingExprSyntax: OptionalChainingExprSyntax? {
+    self.as(OptionalChainingExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `OptionalChainingExprSyntax`.
+  @inlinable
+  public var isOptionalChainingExprSyntax: Bool {
+    self.is(OptionalChainingExprSyntax.self)
+  }
+
+  /// Returns `self` as `OptionalTypeSyntax`, when possible.
+  @inlinable
+  public var asOptionalTypeSyntax: OptionalTypeSyntax? {
+    self.as(OptionalTypeSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `OptionalTypeSyntax`.
+  @inlinable
+  public var isOptionalTypeSyntax: Bool {
+    self.is(OptionalTypeSyntax.self)
+  }
+
+  /// Returns `self` as `OriginallyDefinedInAttributeArgumentsSyntax`, when possible.
+  @inlinable
+  public var asOriginallyDefinedInAttributeArgumentsSyntax: OriginallyDefinedInAttributeArgumentsSyntax? {
+    self.as(OriginallyDefinedInAttributeArgumentsSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `OriginallyDefinedInAttributeArgumentsSyntax`.
+  @inlinable
+  public var isOriginallyDefinedInAttributeArgumentsSyntax: Bool {
+    self.is(OriginallyDefinedInAttributeArgumentsSyntax.self)
+  }
+
+  /// Returns `self` as `PackElementExprSyntax`, when possible.
+  @inlinable
+  public var asPackElementExprSyntax: PackElementExprSyntax? {
+    self.as(PackElementExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `PackElementExprSyntax`.
+  @inlinable
+  public var isPackElementExprSyntax: Bool {
+    self.is(PackElementExprSyntax.self)
+  }
+
+  /// Returns `self` as `PackElementTypeSyntax`, when possible.
+  @inlinable
+  public var asPackElementTypeSyntax: PackElementTypeSyntax? {
+    self.as(PackElementTypeSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `PackElementTypeSyntax`.
+  @inlinable
+  public var isPackElementTypeSyntax: Bool {
+    self.is(PackElementTypeSyntax.self)
+  }
+
+  /// Returns `self` as `PackExpansionExprSyntax`, when possible.
+  @inlinable
+  public var asPackExpansionExprSyntax: PackExpansionExprSyntax? {
+    self.as(PackExpansionExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `PackExpansionExprSyntax`.
+  @inlinable
+  public var isPackExpansionExprSyntax: Bool {
+    self.is(PackExpansionExprSyntax.self)
+  }
+
+  /// Returns `self` as `PackExpansionTypeSyntax`, when possible.
+  @inlinable
+  public var asPackExpansionTypeSyntax: PackExpansionTypeSyntax? {
+    self.as(PackExpansionTypeSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `PackExpansionTypeSyntax`.
+  @inlinable
+  public var isPackExpansionTypeSyntax: Bool {
+    self.is(PackExpansionTypeSyntax.self)
+  }
+
+  /// Returns `self` as `PatternBindingListSyntax`, when possible.
+  @inlinable
+  public var asPatternBindingListSyntax: PatternBindingListSyntax? {
+    self.as(PatternBindingListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `PatternBindingListSyntax`.
+  @inlinable
+  public var isPatternBindingListSyntax: Bool {
+    self.is(PatternBindingListSyntax.self)
+  }
+
+  /// Returns `self` as `PatternBindingSyntax`, when possible.
+  @inlinable
+  public var asPatternBindingSyntax: PatternBindingSyntax? {
+    self.as(PatternBindingSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `PatternBindingSyntax`.
+  @inlinable
+  public var isPatternBindingSyntax: Bool {
+    self.is(PatternBindingSyntax.self)
+  }
+
+  /// Returns `self` as `PatternExprSyntax`, when possible.
+  @inlinable
+  public var asPatternExprSyntax: PatternExprSyntax? {
+    self.as(PatternExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `PatternExprSyntax`.
+  @inlinable
+  public var isPatternExprSyntax: Bool {
+    self.is(PatternExprSyntax.self)
+  }
+
+  /// Returns `self` as `PatternSyntax`, when possible.
+  @inlinable
+  public var asPatternSyntax: PatternSyntax? {
+    self.as(PatternSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `PatternSyntax`.
+  @inlinable
+  public var isPatternSyntax: Bool {
+    self.is(PatternSyntax.self)
+  }
+
+  /// Returns `self` as `PlatformVersionItemListSyntax`, when possible.
+  @inlinable
+  public var asPlatformVersionItemListSyntax: PlatformVersionItemListSyntax? {
+    self.as(PlatformVersionItemListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `PlatformVersionItemListSyntax`.
+  @inlinable
+  public var isPlatformVersionItemListSyntax: Bool {
+    self.is(PlatformVersionItemListSyntax.self)
+  }
+
+  /// Returns `self` as `PlatformVersionItemSyntax`, when possible.
+  @inlinable
+  public var asPlatformVersionItemSyntax: PlatformVersionItemSyntax? {
+    self.as(PlatformVersionItemSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `PlatformVersionItemSyntax`.
+  @inlinable
+  public var isPlatformVersionItemSyntax: Bool {
+    self.is(PlatformVersionItemSyntax.self)
+  }
+
+  /// Returns `self` as `PlatformVersionSyntax`, when possible.
+  @inlinable
+  public var asPlatformVersionSyntax: PlatformVersionSyntax? {
+    self.as(PlatformVersionSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `PlatformVersionSyntax`.
+  @inlinable
+  public var isPlatformVersionSyntax: Bool {
+    self.is(PlatformVersionSyntax.self)
+  }
+
+  /// Returns `self` as `PostfixIfConfigExprSyntax`, when possible.
+  @inlinable
+  public var asPostfixIfConfigExprSyntax: PostfixIfConfigExprSyntax? {
+    self.as(PostfixIfConfigExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `PostfixIfConfigExprSyntax`.
+  @inlinable
+  public var isPostfixIfConfigExprSyntax: Bool {
+    self.is(PostfixIfConfigExprSyntax.self)
+  }
+
+  /// Returns `self` as `PostfixOperatorExprSyntax`, when possible.
+  @inlinable
+  public var asPostfixOperatorExprSyntax: PostfixOperatorExprSyntax? {
+    self.as(PostfixOperatorExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `PostfixOperatorExprSyntax`.
+  @inlinable
+  public var isPostfixOperatorExprSyntax: Bool {
+    self.is(PostfixOperatorExprSyntax.self)
+  }
+
+  /// Returns `self` as `PoundSourceLocationArgumentsSyntax`, when possible.
+  @inlinable
+  public var asPoundSourceLocationArgumentsSyntax: PoundSourceLocationArgumentsSyntax? {
+    self.as(PoundSourceLocationArgumentsSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `PoundSourceLocationArgumentsSyntax`.
+  @inlinable
+  public var isPoundSourceLocationArgumentsSyntax: Bool {
+    self.is(PoundSourceLocationArgumentsSyntax.self)
+  }
+
+  /// Returns `self` as `PoundSourceLocationSyntax`, when possible.
+  @inlinable
+  public var asPoundSourceLocationSyntax: PoundSourceLocationSyntax? {
+    self.as(PoundSourceLocationSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `PoundSourceLocationSyntax`.
+  @inlinable
+  public var isPoundSourceLocationSyntax: Bool {
+    self.is(PoundSourceLocationSyntax.self)
+  }
+
+  /// Returns `self` as `PrecedenceGroupAssignmentSyntax`, when possible.
+  @inlinable
+  public var asPrecedenceGroupAssignmentSyntax: PrecedenceGroupAssignmentSyntax? {
+    self.as(PrecedenceGroupAssignmentSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `PrecedenceGroupAssignmentSyntax`.
+  @inlinable
+  public var isPrecedenceGroupAssignmentSyntax: Bool {
+    self.is(PrecedenceGroupAssignmentSyntax.self)
+  }
+
+  /// Returns `self` as `PrecedenceGroupAssociativitySyntax`, when possible.
+  @inlinable
+  public var asPrecedenceGroupAssociativitySyntax: PrecedenceGroupAssociativitySyntax? {
+    self.as(PrecedenceGroupAssociativitySyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `PrecedenceGroupAssociativitySyntax`.
+  @inlinable
+  public var isPrecedenceGroupAssociativitySyntax: Bool {
+    self.is(PrecedenceGroupAssociativitySyntax.self)
+  }
+
+  /// Returns `self` as `PrecedenceGroupAttributeListSyntax`, when possible.
+  @inlinable
+  public var asPrecedenceGroupAttributeListSyntax: PrecedenceGroupAttributeListSyntax? {
+    self.as(PrecedenceGroupAttributeListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `PrecedenceGroupAttributeListSyntax`.
+  @inlinable
+  public var isPrecedenceGroupAttributeListSyntax: Bool {
+    self.is(PrecedenceGroupAttributeListSyntax.self)
+  }
+
+  /// Returns `self` as `PrecedenceGroupDeclSyntax`, when possible.
+  @inlinable
+  public var asPrecedenceGroupDeclSyntax: PrecedenceGroupDeclSyntax? {
+    self.as(PrecedenceGroupDeclSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `PrecedenceGroupDeclSyntax`.
+  @inlinable
+  public var isPrecedenceGroupDeclSyntax: Bool {
+    self.is(PrecedenceGroupDeclSyntax.self)
+  }
+
+  /// Returns `self` as `PrecedenceGroupNameListSyntax`, when possible.
+  @inlinable
+  public var asPrecedenceGroupNameListSyntax: PrecedenceGroupNameListSyntax? {
+    self.as(PrecedenceGroupNameListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `PrecedenceGroupNameListSyntax`.
+  @inlinable
+  public var isPrecedenceGroupNameListSyntax: Bool {
+    self.is(PrecedenceGroupNameListSyntax.self)
+  }
+
+  /// Returns `self` as `PrecedenceGroupNameSyntax`, when possible.
+  @inlinable
+  public var asPrecedenceGroupNameSyntax: PrecedenceGroupNameSyntax? {
+    self.as(PrecedenceGroupNameSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `PrecedenceGroupNameSyntax`.
+  @inlinable
+  public var isPrecedenceGroupNameSyntax: Bool {
+    self.is(PrecedenceGroupNameSyntax.self)
+  }
+
+  /// Returns `self` as `PrecedenceGroupRelationSyntax`, when possible.
+  @inlinable
+  public var asPrecedenceGroupRelationSyntax: PrecedenceGroupRelationSyntax? {
+    self.as(PrecedenceGroupRelationSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `PrecedenceGroupRelationSyntax`.
+  @inlinable
+  public var isPrecedenceGroupRelationSyntax: Bool {
+    self.is(PrecedenceGroupRelationSyntax.self)
+  }
+
+  /// Returns `self` as `PrefixOperatorExprSyntax`, when possible.
+  @inlinable
+  public var asPrefixOperatorExprSyntax: PrefixOperatorExprSyntax? {
+    self.as(PrefixOperatorExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `PrefixOperatorExprSyntax`.
+  @inlinable
+  public var isPrefixOperatorExprSyntax: Bool {
+    self.is(PrefixOperatorExprSyntax.self)
+  }
+
+  /// Returns `self` as `PrimaryAssociatedTypeClauseSyntax`, when possible.
+  @inlinable
+  public var asPrimaryAssociatedTypeClauseSyntax: PrimaryAssociatedTypeClauseSyntax? {
+    self.as(PrimaryAssociatedTypeClauseSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `PrimaryAssociatedTypeClauseSyntax`.
+  @inlinable
+  public var isPrimaryAssociatedTypeClauseSyntax: Bool {
+    self.is(PrimaryAssociatedTypeClauseSyntax.self)
+  }
+
+  /// Returns `self` as `PrimaryAssociatedTypeListSyntax`, when possible.
+  @inlinable
+  public var asPrimaryAssociatedTypeListSyntax: PrimaryAssociatedTypeListSyntax? {
+    self.as(PrimaryAssociatedTypeListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `PrimaryAssociatedTypeListSyntax`.
+  @inlinable
+  public var isPrimaryAssociatedTypeListSyntax: Bool {
+    self.is(PrimaryAssociatedTypeListSyntax.self)
+  }
+
+  /// Returns `self` as `PrimaryAssociatedTypeSyntax`, when possible.
+  @inlinable
+  public var asPrimaryAssociatedTypeSyntax: PrimaryAssociatedTypeSyntax? {
+    self.as(PrimaryAssociatedTypeSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `PrimaryAssociatedTypeSyntax`.
+  @inlinable
+  public var isPrimaryAssociatedTypeSyntax: Bool {
+    self.is(PrimaryAssociatedTypeSyntax.self)
+  }
+
+  /// Returns `self` as `ProtocolDeclSyntax`, when possible.
+  @inlinable
+  public var asProtocolDeclSyntax: ProtocolDeclSyntax? {
+    self.as(ProtocolDeclSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ProtocolDeclSyntax`.
+  @inlinable
+  public var isProtocolDeclSyntax: Bool {
+    self.is(ProtocolDeclSyntax.self)
+  }
+
+  /// Returns `self` as `RegexLiteralExprSyntax`, when possible.
+  @inlinable
+  public var asRegexLiteralExprSyntax: RegexLiteralExprSyntax? {
+    self.as(RegexLiteralExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `RegexLiteralExprSyntax`.
+  @inlinable
+  public var isRegexLiteralExprSyntax: Bool {
+    self.is(RegexLiteralExprSyntax.self)
+  }
+
+  /// Returns `self` as `RepeatStmtSyntax`, when possible.
+  @inlinable
+  public var asRepeatStmtSyntax: RepeatStmtSyntax? {
+    self.as(RepeatStmtSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `RepeatStmtSyntax`.
+  @inlinable
+  public var isRepeatStmtSyntax: Bool {
+    self.is(RepeatStmtSyntax.self)
+  }
+
+  /// Returns `self` as `ReturnClauseSyntax`, when possible.
+  @inlinable
+  public var asReturnClauseSyntax: ReturnClauseSyntax? {
+    self.as(ReturnClauseSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ReturnClauseSyntax`.
+  @inlinable
+  public var isReturnClauseSyntax: Bool {
+    self.is(ReturnClauseSyntax.self)
+  }
+
+  /// Returns `self` as `ReturnStmtSyntax`, when possible.
+  @inlinable
+  public var asReturnStmtSyntax: ReturnStmtSyntax? {
+    self.as(ReturnStmtSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ReturnStmtSyntax`.
+  @inlinable
+  public var isReturnStmtSyntax: Bool {
+    self.is(ReturnStmtSyntax.self)
+  }
+
+  /// Returns `self` as `SameTypeRequirementSyntax`, when possible.
+  @inlinable
+  public var asSameTypeRequirementSyntax: SameTypeRequirementSyntax? {
+    self.as(SameTypeRequirementSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `SameTypeRequirementSyntax`.
+  @inlinable
+  public var isSameTypeRequirementSyntax: Bool {
+    self.is(SameTypeRequirementSyntax.self)
+  }
+
+  /// Returns `self` as `SequenceExprSyntax`, when possible.
+  @inlinable
+  public var asSequenceExprSyntax: SequenceExprSyntax? {
+    self.as(SequenceExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `SequenceExprSyntax`.
+  @inlinable
+  public var isSequenceExprSyntax: Bool {
+    self.is(SequenceExprSyntax.self)
+  }
+
+  /// Returns `self` as `SimpleStringLiteralExprSyntax`, when possible.
+  @inlinable
+  public var asSimpleStringLiteralExprSyntax: SimpleStringLiteralExprSyntax? {
+    self.as(SimpleStringLiteralExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `SimpleStringLiteralExprSyntax`.
+  @inlinable
+  public var isSimpleStringLiteralExprSyntax: Bool {
+    self.is(SimpleStringLiteralExprSyntax.self)
+  }
+
+  /// Returns `self` as `SimpleStringLiteralSegmentListSyntax`, when possible.
+  @inlinable
+  public var asSimpleStringLiteralSegmentListSyntax: SimpleStringLiteralSegmentListSyntax? {
+    self.as(SimpleStringLiteralSegmentListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `SimpleStringLiteralSegmentListSyntax`.
+  @inlinable
+  public var isSimpleStringLiteralSegmentListSyntax: Bool {
+    self.is(SimpleStringLiteralSegmentListSyntax.self)
+  }
+
+  /// Returns `self` as `SimpleTypeSpecifierSyntax`, when possible.
+  @inlinable
+  public var asSimpleTypeSpecifierSyntax: SimpleTypeSpecifierSyntax? {
+    self.as(SimpleTypeSpecifierSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `SimpleTypeSpecifierSyntax`.
+  @inlinable
+  public var isSimpleTypeSpecifierSyntax: Bool {
+    self.is(SimpleTypeSpecifierSyntax.self)
+  }
+
+  /// Returns `self` as `SomeOrAnyTypeSyntax`, when possible.
+  @inlinable
+  public var asSomeOrAnyTypeSyntax: SomeOrAnyTypeSyntax? {
+    self.as(SomeOrAnyTypeSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `SomeOrAnyTypeSyntax`.
+  @inlinable
+  public var isSomeOrAnyTypeSyntax: Bool {
+    self.is(SomeOrAnyTypeSyntax.self)
+  }
+
+  /// Returns `self` as `SourceFileSyntax`, when possible.
+  @inlinable
+  public var asSourceFileSyntax: SourceFileSyntax? {
+    self.as(SourceFileSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `SourceFileSyntax`.
+  @inlinable
+  public var isSourceFileSyntax: Bool {
+    self.is(SourceFileSyntax.self)
+  }
+
+  /// Returns `self` as `SpecializeAttributeArgumentListSyntax`, when possible.
+  @inlinable
+  public var asSpecializeAttributeArgumentListSyntax: SpecializeAttributeArgumentListSyntax? {
+    self.as(SpecializeAttributeArgumentListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `SpecializeAttributeArgumentListSyntax`.
+  @inlinable
+  public var isSpecializeAttributeArgumentListSyntax: Bool {
+    self.is(SpecializeAttributeArgumentListSyntax.self)
+  }
+
+  /// Returns `self` as `SpecializeAvailabilityArgumentSyntax`, when possible.
+  @inlinable
+  public var asSpecializeAvailabilityArgumentSyntax: SpecializeAvailabilityArgumentSyntax? {
+    self.as(SpecializeAvailabilityArgumentSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `SpecializeAvailabilityArgumentSyntax`.
+  @inlinable
+  public var isSpecializeAvailabilityArgumentSyntax: Bool {
+    self.is(SpecializeAvailabilityArgumentSyntax.self)
+  }
+
+  /// Returns `self` as `SpecializeTargetFunctionArgumentSyntax`, when possible.
+  @inlinable
+  public var asSpecializeTargetFunctionArgumentSyntax: SpecializeTargetFunctionArgumentSyntax? {
+    self.as(SpecializeTargetFunctionArgumentSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `SpecializeTargetFunctionArgumentSyntax`.
+  @inlinable
+  public var isSpecializeTargetFunctionArgumentSyntax: Bool {
+    self.is(SpecializeTargetFunctionArgumentSyntax.self)
+  }
+
+  /// Returns `self` as `StmtSyntax`, when possible.
+  @inlinable
+  public var asStmtSyntax: StmtSyntax? {
+    self.as(StmtSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `StmtSyntax`.
+  @inlinable
+  public var isStmtSyntax: Bool {
+    self.is(StmtSyntax.self)
+  }
+
+  /// Returns `self` as `StringLiteralExprSyntax`, when possible.
+  @inlinable
+  public var asStringLiteralExprSyntax: StringLiteralExprSyntax? {
+    self.as(StringLiteralExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `StringLiteralExprSyntax`.
+  @inlinable
+  public var isStringLiteralExprSyntax: Bool {
+    self.is(StringLiteralExprSyntax.self)
+  }
+
+  /// Returns `self` as `StringLiteralSegmentListSyntax`, when possible.
+  @inlinable
+  public var asStringLiteralSegmentListSyntax: StringLiteralSegmentListSyntax? {
+    self.as(StringLiteralSegmentListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `StringLiteralSegmentListSyntax`.
+  @inlinable
+  public var isStringLiteralSegmentListSyntax: Bool {
+    self.is(StringLiteralSegmentListSyntax.self)
+  }
+
+  /// Returns `self` as `StringSegmentSyntax`, when possible.
+  @inlinable
+  public var asStringSegmentSyntax: StringSegmentSyntax? {
+    self.as(StringSegmentSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `StringSegmentSyntax`.
+  @inlinable
+  public var isStringSegmentSyntax: Bool {
+    self.is(StringSegmentSyntax.self)
+  }
+
+  /// Returns `self` as `StructDeclSyntax`, when possible.
+  @inlinable
+  public var asStructDeclSyntax: StructDeclSyntax? {
+    self.as(StructDeclSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `StructDeclSyntax`.
+  @inlinable
+  public var isStructDeclSyntax: Bool {
+    self.is(StructDeclSyntax.self)
+  }
+
+  /// Returns `self` as `SubscriptCallExprSyntax`, when possible.
+  @inlinable
+  public var asSubscriptCallExprSyntax: SubscriptCallExprSyntax? {
+    self.as(SubscriptCallExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `SubscriptCallExprSyntax`.
+  @inlinable
+  public var isSubscriptCallExprSyntax: Bool {
+    self.is(SubscriptCallExprSyntax.self)
+  }
+
+  /// Returns `self` as `SubscriptDeclSyntax`, when possible.
+  @inlinable
+  public var asSubscriptDeclSyntax: SubscriptDeclSyntax? {
+    self.as(SubscriptDeclSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `SubscriptDeclSyntax`.
+  @inlinable
+  public var isSubscriptDeclSyntax: Bool {
+    self.is(SubscriptDeclSyntax.self)
+  }
+
+  /// Returns `self` as `SuperExprSyntax`, when possible.
+  @inlinable
+  public var asSuperExprSyntax: SuperExprSyntax? {
+    self.as(SuperExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `SuperExprSyntax`.
+  @inlinable
+  public var isSuperExprSyntax: Bool {
+    self.is(SuperExprSyntax.self)
+  }
+
+  /// Returns `self` as `SuppressedTypeSyntax`, when possible.
+  @inlinable
+  public var asSuppressedTypeSyntax: SuppressedTypeSyntax? {
+    self.as(SuppressedTypeSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `SuppressedTypeSyntax`.
+  @inlinable
+  public var isSuppressedTypeSyntax: Bool {
+    self.is(SuppressedTypeSyntax.self)
+  }
+
+  /// Returns `self` as `SwitchCaseItemListSyntax`, when possible.
+  @inlinable
+  public var asSwitchCaseItemListSyntax: SwitchCaseItemListSyntax? {
+    self.as(SwitchCaseItemListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `SwitchCaseItemListSyntax`.
+  @inlinable
+  public var isSwitchCaseItemListSyntax: Bool {
+    self.is(SwitchCaseItemListSyntax.self)
+  }
+
+  /// Returns `self` as `SwitchCaseItemSyntax`, when possible.
+  @inlinable
+  public var asSwitchCaseItemSyntax: SwitchCaseItemSyntax? {
+    self.as(SwitchCaseItemSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `SwitchCaseItemSyntax`.
+  @inlinable
+  public var isSwitchCaseItemSyntax: Bool {
+    self.is(SwitchCaseItemSyntax.self)
+  }
+
+  /// Returns `self` as `SwitchCaseLabelSyntax`, when possible.
+  @inlinable
+  public var asSwitchCaseLabelSyntax: SwitchCaseLabelSyntax? {
+    self.as(SwitchCaseLabelSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `SwitchCaseLabelSyntax`.
+  @inlinable
+  public var isSwitchCaseLabelSyntax: Bool {
+    self.is(SwitchCaseLabelSyntax.self)
+  }
+
+  /// Returns `self` as `SwitchCaseListSyntax`, when possible.
+  @inlinable
+  public var asSwitchCaseListSyntax: SwitchCaseListSyntax? {
+    self.as(SwitchCaseListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `SwitchCaseListSyntax`.
+  @inlinable
+  public var isSwitchCaseListSyntax: Bool {
+    self.is(SwitchCaseListSyntax.self)
+  }
+
+  /// Returns `self` as `SwitchCaseSyntax`, when possible.
+  @inlinable
+  public var asSwitchCaseSyntax: SwitchCaseSyntax? {
+    self.as(SwitchCaseSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `SwitchCaseSyntax`.
+  @inlinable
+  public var isSwitchCaseSyntax: Bool {
+    self.is(SwitchCaseSyntax.self)
+  }
+
+  /// Returns `self` as `SwitchDefaultLabelSyntax`, when possible.
+  @inlinable
+  public var asSwitchDefaultLabelSyntax: SwitchDefaultLabelSyntax? {
+    self.as(SwitchDefaultLabelSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `SwitchDefaultLabelSyntax`.
+  @inlinable
+  public var isSwitchDefaultLabelSyntax: Bool {
+    self.is(SwitchDefaultLabelSyntax.self)
+  }
+
+  /// Returns `self` as `SwitchExprSyntax`, when possible.
+  @inlinable
+  public var asSwitchExprSyntax: SwitchExprSyntax? {
+    self.as(SwitchExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `SwitchExprSyntax`.
+  @inlinable
+  public var isSwitchExprSyntax: Bool {
+    self.is(SwitchExprSyntax.self)
+  }
+
+  /// Returns `self` as `TernaryExprSyntax`, when possible.
+  @inlinable
+  public var asTernaryExprSyntax: TernaryExprSyntax? {
+    self.as(TernaryExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `TernaryExprSyntax`.
+  @inlinable
+  public var isTernaryExprSyntax: Bool {
+    self.is(TernaryExprSyntax.self)
+  }
+
+  /// Returns `self` as `ThrowStmtSyntax`, when possible.
+  @inlinable
+  public var asThrowStmtSyntax: ThrowStmtSyntax? {
+    self.as(ThrowStmtSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ThrowStmtSyntax`.
+  @inlinable
+  public var isThrowStmtSyntax: Bool {
+    self.is(ThrowStmtSyntax.self)
+  }
+
+  /// Returns `self` as `ThrowsClauseSyntax`, when possible.
+  @inlinable
+  public var asThrowsClauseSyntax: ThrowsClauseSyntax? {
+    self.as(ThrowsClauseSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ThrowsClauseSyntax`.
+  @inlinable
+  public var isThrowsClauseSyntax: Bool {
+    self.is(ThrowsClauseSyntax.self)
+  }
+
+  /// Returns `self` as `TokenSyntax`, when possible.
+  @inlinable
+  public var asTokenSyntax: TokenSyntax? {
+    self.as(TokenSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `TokenSyntax`.
+  @inlinable
+  public var isTokenSyntax: Bool {
+    self.is(TokenSyntax.self)
+  }
+
+  /// Returns `self` as `TryExprSyntax`, when possible.
+  @inlinable
+  public var asTryExprSyntax: TryExprSyntax? {
+    self.as(TryExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `TryExprSyntax`.
+  @inlinable
+  public var isTryExprSyntax: Bool {
+    self.is(TryExprSyntax.self)
+  }
+
+  /// Returns `self` as `TupleExprSyntax`, when possible.
+  @inlinable
+  public var asTupleExprSyntax: TupleExprSyntax? {
+    self.as(TupleExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `TupleExprSyntax`.
+  @inlinable
+  public var isTupleExprSyntax: Bool {
+    self.is(TupleExprSyntax.self)
+  }
+
+  /// Returns `self` as `TuplePatternElementListSyntax`, when possible.
+  @inlinable
+  public var asTuplePatternElementListSyntax: TuplePatternElementListSyntax? {
+    self.as(TuplePatternElementListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `TuplePatternElementListSyntax`.
+  @inlinable
+  public var isTuplePatternElementListSyntax: Bool {
+    self.is(TuplePatternElementListSyntax.self)
+  }
+
+  /// Returns `self` as `TuplePatternElementSyntax`, when possible.
+  @inlinable
+  public var asTuplePatternElementSyntax: TuplePatternElementSyntax? {
+    self.as(TuplePatternElementSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `TuplePatternElementSyntax`.
+  @inlinable
+  public var isTuplePatternElementSyntax: Bool {
+    self.is(TuplePatternElementSyntax.self)
+  }
+
+  /// Returns `self` as `TuplePatternSyntax`, when possible.
+  @inlinable
+  public var asTuplePatternSyntax: TuplePatternSyntax? {
+    self.as(TuplePatternSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `TuplePatternSyntax`.
+  @inlinable
+  public var isTuplePatternSyntax: Bool {
+    self.is(TuplePatternSyntax.self)
+  }
+
+  /// Returns `self` as `TupleTypeElementListSyntax`, when possible.
+  @inlinable
+  public var asTupleTypeElementListSyntax: TupleTypeElementListSyntax? {
+    self.as(TupleTypeElementListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `TupleTypeElementListSyntax`.
+  @inlinable
+  public var isTupleTypeElementListSyntax: Bool {
+    self.is(TupleTypeElementListSyntax.self)
+  }
+
+  /// Returns `self` as `TupleTypeElementSyntax`, when possible.
+  @inlinable
+  public var asTupleTypeElementSyntax: TupleTypeElementSyntax? {
+    self.as(TupleTypeElementSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `TupleTypeElementSyntax`.
+  @inlinable
+  public var isTupleTypeElementSyntax: Bool {
+    self.is(TupleTypeElementSyntax.self)
+  }
+
+  /// Returns `self` as `TupleTypeSyntax`, when possible.
+  @inlinable
+  public var asTupleTypeSyntax: TupleTypeSyntax? {
+    self.as(TupleTypeSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `TupleTypeSyntax`.
+  @inlinable
+  public var isTupleTypeSyntax: Bool {
+    self.is(TupleTypeSyntax.self)
+  }
+
+  /// Returns `self` as `TypeAliasDeclSyntax`, when possible.
+  @inlinable
+  public var asTypeAliasDeclSyntax: TypeAliasDeclSyntax? {
+    self.as(TypeAliasDeclSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `TypeAliasDeclSyntax`.
+  @inlinable
+  public var isTypeAliasDeclSyntax: Bool {
+    self.is(TypeAliasDeclSyntax.self)
+  }
+
+  /// Returns `self` as `TypeAnnotationSyntax`, when possible.
+  @inlinable
+  public var asTypeAnnotationSyntax: TypeAnnotationSyntax? {
+    self.as(TypeAnnotationSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `TypeAnnotationSyntax`.
+  @inlinable
+  public var isTypeAnnotationSyntax: Bool {
+    self.is(TypeAnnotationSyntax.self)
+  }
+
+  /// Returns `self` as `TypeEffectSpecifiersSyntax`, when possible.
+  @inlinable
+  public var asTypeEffectSpecifiersSyntax: TypeEffectSpecifiersSyntax? {
+    self.as(TypeEffectSpecifiersSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `TypeEffectSpecifiersSyntax`.
+  @inlinable
+  public var isTypeEffectSpecifiersSyntax: Bool {
+    self.is(TypeEffectSpecifiersSyntax.self)
+  }
+
+  /// Returns `self` as `TypeExprSyntax`, when possible.
+  @inlinable
+  public var asTypeExprSyntax: TypeExprSyntax? {
+    self.as(TypeExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `TypeExprSyntax`.
+  @inlinable
+  public var isTypeExprSyntax: Bool {
+    self.is(TypeExprSyntax.self)
+  }
+
+  /// Returns `self` as `TypeInitializerClauseSyntax`, when possible.
+  @inlinable
+  public var asTypeInitializerClauseSyntax: TypeInitializerClauseSyntax? {
+    self.as(TypeInitializerClauseSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `TypeInitializerClauseSyntax`.
+  @inlinable
+  public var isTypeInitializerClauseSyntax: Bool {
+    self.is(TypeInitializerClauseSyntax.self)
+  }
+
+  /// Returns `self` as `TypeSpecifierListSyntax`, when possible.
+  @inlinable
+  public var asTypeSpecifierListSyntax: TypeSpecifierListSyntax? {
+    self.as(TypeSpecifierListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `TypeSpecifierListSyntax`.
+  @inlinable
+  public var isTypeSpecifierListSyntax: Bool {
+    self.is(TypeSpecifierListSyntax.self)
+  }
+
+  /// Returns `self` as `TypeSyntax`, when possible.
+  @inlinable
+  public var asTypeSyntax: TypeSyntax? {
+    self.as(TypeSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `TypeSyntax`.
+  @inlinable
+  public var isTypeSyntax: Bool {
+    self.is(TypeSyntax.self)
+  }
+
+  /// Returns `self` as `UnexpectedNodesSyntax`, when possible.
+  @inlinable
+  public var asUnexpectedNodesSyntax: UnexpectedNodesSyntax? {
+    self.as(UnexpectedNodesSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `UnexpectedNodesSyntax`.
+  @inlinable
+  public var isUnexpectedNodesSyntax: Bool {
+    self.is(UnexpectedNodesSyntax.self)
+  }
+
+  /// Returns `self` as `UnresolvedAsExprSyntax`, when possible.
+  @inlinable
+  public var asUnresolvedAsExprSyntax: UnresolvedAsExprSyntax? {
+    self.as(UnresolvedAsExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `UnresolvedAsExprSyntax`.
+  @inlinable
+  public var isUnresolvedAsExprSyntax: Bool {
+    self.is(UnresolvedAsExprSyntax.self)
+  }
+
+  /// Returns `self` as `UnresolvedIsExprSyntax`, when possible.
+  @inlinable
+  public var asUnresolvedIsExprSyntax: UnresolvedIsExprSyntax? {
+    self.as(UnresolvedIsExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `UnresolvedIsExprSyntax`.
+  @inlinable
+  public var isUnresolvedIsExprSyntax: Bool {
+    self.is(UnresolvedIsExprSyntax.self)
+  }
+
+  /// Returns `self` as `UnresolvedTernaryExprSyntax`, when possible.
+  @inlinable
+  public var asUnresolvedTernaryExprSyntax: UnresolvedTernaryExprSyntax? {
+    self.as(UnresolvedTernaryExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `UnresolvedTernaryExprSyntax`.
+  @inlinable
+  public var isUnresolvedTernaryExprSyntax: Bool {
+    self.is(UnresolvedTernaryExprSyntax.self)
+  }
+
+  /// Returns `self` as `UnsafeExprSyntax`, when possible.
+  @inlinable
+  public var asUnsafeExprSyntax: UnsafeExprSyntax? {
+    self.as(UnsafeExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `UnsafeExprSyntax`.
+  @inlinable
+  public var isUnsafeExprSyntax: Bool {
+    self.is(UnsafeExprSyntax.self)
+  }
+
+  /// Returns `self` as `ValueBindingPatternSyntax`, when possible.
+  @inlinable
+  public var asValueBindingPatternSyntax: ValueBindingPatternSyntax? {
+    self.as(ValueBindingPatternSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `ValueBindingPatternSyntax`.
+  @inlinable
+  public var isValueBindingPatternSyntax: Bool {
+    self.is(ValueBindingPatternSyntax.self)
+  }
+
+  /// Returns `self` as `VariableDeclSyntax`, when possible.
+  @inlinable
+  public var asVariableDeclSyntax: VariableDeclSyntax? {
+    self.as(VariableDeclSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `VariableDeclSyntax`.
+  @inlinable
+  public var isVariableDeclSyntax: Bool {
+    self.is(VariableDeclSyntax.self)
+  }
+
+  /// Returns `self` as `VersionComponentListSyntax`, when possible.
+  @inlinable
+  public var asVersionComponentListSyntax: VersionComponentListSyntax? {
+    self.as(VersionComponentListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `VersionComponentListSyntax`.
+  @inlinable
+  public var isVersionComponentListSyntax: Bool {
+    self.is(VersionComponentListSyntax.self)
+  }
+
+  /// Returns `self` as `VersionComponentSyntax`, when possible.
+  @inlinable
+  public var asVersionComponentSyntax: VersionComponentSyntax? {
+    self.as(VersionComponentSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `VersionComponentSyntax`.
+  @inlinable
+  public var isVersionComponentSyntax: Bool {
+    self.is(VersionComponentSyntax.self)
+  }
+
+  /// Returns `self` as `VersionTupleSyntax`, when possible.
+  @inlinable
+  public var asVersionTupleSyntax: VersionTupleSyntax? {
+    self.as(VersionTupleSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `VersionTupleSyntax`.
+  @inlinable
+  public var isVersionTupleSyntax: Bool {
+    self.is(VersionTupleSyntax.self)
+  }
+
+  /// Returns `self` as `WhereClauseSyntax`, when possible.
+  @inlinable
+  public var asWhereClauseSyntax: WhereClauseSyntax? {
+    self.as(WhereClauseSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `WhereClauseSyntax`.
+  @inlinable
+  public var isWhereClauseSyntax: Bool {
+    self.is(WhereClauseSyntax.self)
+  }
+
+  /// Returns `self` as `WhileStmtSyntax`, when possible.
+  @inlinable
+  public var asWhileStmtSyntax: WhileStmtSyntax? {
+    self.as(WhileStmtSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `WhileStmtSyntax`.
+  @inlinable
+  public var isWhileStmtSyntax: Bool {
+    self.is(WhileStmtSyntax.self)
+  }
+
+  /// Returns `self` as `WildcardPatternSyntax`, when possible.
+  @inlinable
+  public var asWildcardPatternSyntax: WildcardPatternSyntax? {
+    self.as(WildcardPatternSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `WildcardPatternSyntax`.
+  @inlinable
+  public var isWildcardPatternSyntax: Bool {
+    self.is(WildcardPatternSyntax.self)
+  }
+
+  /// Returns `self` as `YieldStmtSyntax`, when possible.
+  @inlinable
+  public var asYieldStmtSyntax: YieldStmtSyntax? {
+    self.as(YieldStmtSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `YieldStmtSyntax`.
+  @inlinable
+  public var isYieldStmtSyntax: Bool {
+    self.is(YieldStmtSyntax.self)
+  }
+
+  /// Returns `self` as `YieldedExpressionListSyntax`, when possible.
+  @inlinable
+  public var asYieldedExpressionListSyntax: YieldedExpressionListSyntax? {
+    self.as(YieldedExpressionListSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `YieldedExpressionListSyntax`.
+  @inlinable
+  public var isYieldedExpressionListSyntax: Bool {
+    self.is(YieldedExpressionListSyntax.self)
+  }
+
+  /// Returns `self` as `YieldedExpressionSyntax`, when possible.
+  @inlinable
+  public var asYieldedExpressionSyntax: YieldedExpressionSyntax? {
+    self.as(YieldedExpressionSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `YieldedExpressionSyntax`.
+  @inlinable
+  public var isYieldedExpressionSyntax: Bool {
+    self.is(YieldedExpressionSyntax.self)
+  }
+
+  /// Returns `self` as `YieldedExpressionsClauseSyntax`, when possible.
+  @inlinable
+  public var asYieldedExpressionsClauseSyntax: YieldedExpressionsClauseSyntax? {
+    self.as(YieldedExpressionsClauseSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `YieldedExpressionsClauseSyntax`.
+  @inlinable
+  public var isYieldedExpressionsClauseSyntax: Bool {
+    self.is(YieldedExpressionsClauseSyntax.self)
+  }
+
+  /// Returns `self` as `_CanImportExprSyntax`, when possible.
+  @inlinable
+  public var asCanImportExprSyntax: _CanImportExprSyntax? {
+    self.as(_CanImportExprSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `_CanImportExprSyntax`.
+  @inlinable
+  public var isCanImportExprSyntax: Bool {
+    self.is(_CanImportExprSyntax.self)
+  }
+
+  /// Returns `self` as `_CanImportVersionInfoSyntax`, when possible.
+  @inlinable
+  public var asCanImportVersionInfoSyntax: _CanImportVersionInfoSyntax? {
+    self.as(_CanImportVersionInfoSyntax.self)
+  }
+
+  /// `true` iff `self` can be viewed as `_CanImportVersionInfoSyntax`.
+  @inlinable
+  public var isCanImportVersionInfoSyntax: Bool {
+    self.is(_CanImportVersionInfoSyntax.self)
+  }
+
+}

--- a/Sources/MacroToolbox/Introspection/Support/SyntaxProtocol+TreeSearch.swift
+++ b/Sources/MacroToolbox/Introspection/Support/SyntaxProtocol+TreeSearch.swift
@@ -1,0 +1,55 @@
+import SwiftSyntax
+
+extension SyntaxProtocol {
+  
+  /// Returns the first syntax element of `type` in the tree rooted at `self`.
+  ///
+  /// The search includes `self`, then proceeds depth-first through children.
+  @inlinable
+  public func firstSyntaxElement<T>(
+    ofType type: T.Type = T.self,
+    viewMode: SyntaxTreeViewMode = .sourceAccurate
+  ) -> T? where T: SyntaxProtocol {
+    if let match = self.as(type) {
+      return match
+    }
+    
+    for child in children(viewMode: viewMode) {
+      if let match = child.firstSyntaxElement(
+        ofType: type,
+        viewMode: viewMode
+      ) {
+        return match
+      }
+    }
+    
+    return nil
+  }
+  
+  /// Returns all syntax elements of `type` in the tree rooted at `self`.
+  ///
+  /// The search includes `self`, then proceeds depth-first through children.
+  @inlinable
+  public func allSyntaxElements<T>(
+    ofType type: T.Type = T.self,
+    viewMode: SyntaxTreeViewMode = .sourceAccurate
+  ) -> [T] where T: SyntaxProtocol {
+    var result: [T] = []
+    
+    if let match = self.as(type) {
+      result.append(match)
+    }
+    
+    for child in children(viewMode: viewMode) {
+      result.append(
+        contentsOf: child.allSyntaxElements(
+          ofType: type,
+          viewMode: viewMode
+        )
+      )
+    }
+    
+    return result
+  }
+  
+}

--- a/Sources/MacroToolbox/MacroProtocols/Conformances/Conditional/AllOrNoneConditionalConformanceMacro.swift
+++ b/Sources/MacroToolbox/MacroProtocols/Conformances/Conditional/AllOrNoneConditionalConformanceMacro.swift
@@ -143,6 +143,7 @@ extension AllOrNoneConditionalConformanceMacro {
     parameters: AllOrNoneConditionalConformanceParameters
   ) throws -> ExtensionDeclSyntax {
     ExtensionDeclSyntax(
+      extensionKeyword: .keyword(.extension, trailingTrivia: .space),
       extendedType: attachmentContext.extendedType,
       inheritanceClause: try conditionalConformanceInheritanceClause(
         in: attachmentContext,
@@ -151,6 +152,13 @@ extension AllOrNoneConditionalConformanceMacro {
       genericWhereClause: try conditionalConformanceRequirementsClause(
         in: attachmentContext,
         parameters: parameters
+      ).with(
+        \.whereKeyword,
+        .keyword(
+          .where,
+          leadingTrivia: .space,
+          trailingTrivia: .space
+        )
       ),
       memberBlock: MemberBlockSyntax(
         declarations: try conditionalConformanceDeclarations(

--- a/Sources/MacroToolbox/MacroProtocols/Conformances/Unconditional/SingleProtocolUnconditionalConformanceMacro.swift
+++ b/Sources/MacroToolbox/MacroProtocols/Conformances/Unconditional/SingleProtocolUnconditionalConformanceMacro.swift
@@ -20,6 +20,7 @@ extension SingleProtocolUnconditionalConformanceMacro {
     in attachmentContext: some ExtensionMacroContextProtocol
   ) throws -> ExtensionDeclSyntax {
     ExtensionDeclSyntax(
+      extensionKeyword: .keyword(.extension, trailingTrivia: .space),
       extendedType: attachmentContext.extendedType,
       inheritanceClause: try unconditionalInheritanceClause(
         in: attachmentContext

--- a/Sources/MacroToolbox/MacroProtocols/Contextualized/Attached/AttachedMacroContextProtocol+Requirements.swift
+++ b/Sources/MacroToolbox/MacroProtocols/Contextualized/Attached/AttachedMacroContextProtocol+Requirements.swift
@@ -28,6 +28,7 @@ extension AttachedMacroContextProtocol {
         """
         Our archetype was \(declarationArchetype), which isn't compatible-with \(attachmentRequirement)!
         """,
+      messageIdentifier: messageIdentifier(),
       function: function,
       fileID: fileID,
       line: line,
@@ -47,6 +48,7 @@ extension AttachedMacroContextProtocol {
     try requireSyntaxProperty(
       \.declaration,
        as: declarationType,
+       messageIdentifier: messageIdentifier(),
        function: function,
        fileID: fileID,
        line: line,
@@ -95,4 +97,3 @@ extension AttachedMacroContextProtocol {
   }
 
 }
-

--- a/Sources/MacroToolbox/Support/String+TupleStringification.swift
+++ b/Sources/MacroToolbox/Support/String+TupleStringification.swift
@@ -7,78 +7,38 @@ extension String {
     forCaption caption: String,
     describingTuple values: (repeat each T)
   ) {
-    var contents: String = "\(caption): "
-    var iterationIndex: Int = 0
-    for value in repeat each values {
-      switch iterationIndex > 0 {
-      case true:
-        contents += ", \(String(describing: value))"
-      case false:
-        contents += String(describing: value)
-      }
-      
-      iterationIndex += 1
-    }
-    
-    self = "(\(contents))"
+    let components = String.tupleComponents(
+      describing: values
+    )
+    self = "(\(caption): \(components.joined(separator: ", ")))"
   }
 
   @inlinable
   package init<each T>(describingTuple values: (repeat each T)) {
-    var contents: String = ""
-    var iterationIndex: Int = 0
-    for value in repeat each values {
-      switch iterationIndex > 0 {
-      case true:
-        contents += ", \(String(describing: value))"
-      case false:
-        contents += String(describing: value)
-      }
-      
-      iterationIndex += 1
-    }
-    
-    self = "(\(contents))"
+    let components = String.tupleComponents(
+      describing: values
+    )
+    self = "(\(components.joined(separator: ", ")))"
   }
-  
+
   @inlinable
   package init<each T>(
     describingLabeledTuple labeledValues: (repeat (String, each T))
   ) {
-    var contents: String = ""
-    var iterationIndex: Int = 0
-    for labeledValue in repeat each labeledValues {
-      switch iterationIndex > 0 {
-      case true:
-        contents += ", \(labeledValue.0): \(String(describing: labeledValue.1))"
-      case false:
-        contents += "\(labeledValue.0): \(String(describing: labeledValue.1))"
-      }
-      
-      iterationIndex += 1
-    }
-    
-    self = "(\(contents))"
+    let components = String.labeledTupleComponents(
+      describing: labeledValues
+    )
+    self = "(\(components.joined(separator: ", ")))"
   }
 
   @inlinable
   package init<each T>(
     reflectingLabeledTuple labeledValues: (repeat (String, each T))
   ) {
-    var contents: String = ""
-    var iterationIndex: Int = 0
-    for labeledValue in repeat each labeledValues {
-      switch iterationIndex > 0 {
-      case true:
-        contents += ", \(labeledValue.0): \(String(reflecting: labeledValue.1))"
-      case false:
-        contents += "\(labeledValue.0): \(String(reflecting: labeledValue.1))"
-      }
-      
-      iterationIndex += 1
-    }
-    
-    self = "(\(contents))"
+    let components = String.labeledTupleComponents(
+      reflecting: labeledValues
+    )
+    self = "(\(components.joined(separator: ", ")))"
   }
 
   /// Prepares a constructor-like string with a mix of labeled and unlabeled arguments (e.g. `Modulator(target, using: modulator)`).
@@ -91,20 +51,10 @@ extension String {
     forConstructorOf type: Parent.Type,
     arguments labeledArguments: (repeat (String?, each T))
   ) {
-    var contents: String = ""
-    var iterationIndex: Int = 0
-    for labeledValue in repeat each labeledArguments {
-      switch iterationIndex > 0 {
-      case true:
-        contents += ", \(labeledValue.0.argumentLabelRepresentation)\(String(reflecting: labeledValue.1))"
-      case false:
-        contents += "\(labeledValue.0.argumentLabelRepresentation)\(String(reflecting: labeledValue.1))"
-      }
-      
-      iterationIndex += 1
-    }
-    
-    self = "\(String(reflecting: type))(\(contents))"
+    let components = String.constructorArgumentComponents(
+      reflecting: labeledArguments
+    )
+    self = "\(String(reflecting: type))(\(components.joined(separator: ", ")))"
   }
 
   /// Constructs a constructor-like string w/completely-unlabeled arguments (e.g. `Foo(x,y,z)`).
@@ -113,26 +63,111 @@ extension String {
     forConstructorOf type: Parent.Type,
     unlabeledArguments: (repeat each T)
   ) {
-    var contents: String = ""
-    var iterationIndex: Int = 0
-    for unlabeledArgument in repeat each unlabeledArguments {
-      switch iterationIndex > 0 {
-      case true:
-        contents += ", \(String(reflecting: unlabeledArgument))"
-      case false:
-        contents += "\(String(reflecting: unlabeledArgument))"
-      }
-      
-      iterationIndex += 1
+    let components = String.tupleComponents(
+      reflecting: unlabeledArguments
+    )
+    self = "\(String(reflecting: type))(\(components.joined(separator: ", ")))"
+  }
+
+}
+
+extension String {
+
+  @usableFromInline
+  package static func tupleComponents(
+    describing value: Any
+  ) -> [String] {
+    Mirror(reflecting: value).children.map { child in
+      String(describing: child.value)
     }
-    
-    self = "\(String(reflecting: type))(\(contents))"
+  }
+
+  @usableFromInline
+  package static func tupleComponents(
+    reflecting value: Any
+  ) -> [String] {
+    Mirror(reflecting: value).children.map { child in
+      String(reflecting: child.value)
+    }
+  }
+
+  @usableFromInline
+  package static func labeledTupleComponents(
+    describing value: Any
+  ) -> [String] {
+    tuplePairComponents(from: value) { pair in
+      "\(pair.label): \(String(describing: pair.value))"
+    }
+  }
+
+  @usableFromInline
+  package static func labeledTupleComponents(
+    reflecting value: Any
+  ) -> [String] {
+    tuplePairComponents(from: value) { pair in
+      "\(pair.label): \(String(reflecting: pair.value))"
+    }
+  }
+
+  @usableFromInline
+  package static func constructorArgumentComponents(
+    reflecting value: Any
+  ) -> [String] {
+    Mirror(reflecting: value).children.map { child in
+      let pairChildren = Array(Mirror(reflecting: child.value).children)
+      guard
+        pairChildren.count == 2,
+        let label = parsedConstructorArgumentLabel(
+          from: pairChildren[0].value
+        )
+      else {
+        return String(describing: child.value)
+      }
+
+      return "\(label.argumentLabelRepresentation)\(String(reflecting: pairChildren[1].value))"
+    }
+  }
+
+  @usableFromInline
+  package static func parsedConstructorArgumentLabel(from value: Any) -> String?? {
+    if let label = value as? String {
+      return Optional.some(Optional.some(label))
+    }
+
+    if let optionalLabel = value as? String? {
+      return Optional.some(optionalLabel)
+    }
+
+    return nil
+  }
+
+  @usableFromInline
+  package static func tuplePairComponents(
+    from value: Any,
+    transform: ((label: String, value: Any)) -> String
+  ) -> [String] {
+    Mirror(reflecting: value).children.map { child in
+      let pairChildren = Array(Mirror(reflecting: child.value).children)
+      guard
+        pairChildren.count == 2,
+        let label = pairChildren[0].value as? String
+      else {
+        return String(describing: child.value)
+      }
+
+      return transform(
+        (
+          label: label,
+          value: pairChildren[1].value
+        )
+      )
+    }
   }
 
 }
 
 extension Optional<String> {
-  
+
   @inlinable
   package var argumentLabelRepresentation: String {
     guard
@@ -141,8 +176,8 @@ extension Optional<String> {
     else {
       return ""
     }
-    
+
     return "\(label): "
   }
-  
+
 }

--- a/Sources/MacroToolbox/Support/String+TupleStringification.swift
+++ b/Sources/MacroToolbox/Support/String+TupleStringification.swift
@@ -7,17 +7,19 @@ extension String {
     forCaption caption: String,
     describingTuple values: (repeat each T)
   ) {
-    let components = String.tupleComponents(
-      describing: values
-    )
+    var components: [String] = []
+    for value in repeat each values {
+      components.append(String(describing: value))
+    }
     self = "(\(caption): \(components.joined(separator: ", ")))"
   }
 
   @inlinable
   package init<each T>(describingTuple values: (repeat each T)) {
-    let components = String.tupleComponents(
-      describing: values
-    )
+    var components: [String] = []
+    for value in repeat each values {
+      components.append(String(describing: value))
+    }
     self = "(\(components.joined(separator: ", ")))"
   }
 
@@ -25,9 +27,10 @@ extension String {
   package init<each T>(
     describingLabeledTuple labeledValues: (repeat (String, each T))
   ) {
-    let components = String.labeledTupleComponents(
-      describing: labeledValues
-    )
+    var components: [String] = []
+    for labeledValue in repeat each labeledValues {
+      components.append("\(labeledValue.0): \(String(describing: labeledValue.1))")
+    }
     self = "(\(components.joined(separator: ", ")))"
   }
 
@@ -35,9 +38,10 @@ extension String {
   package init<each T>(
     reflectingLabeledTuple labeledValues: (repeat (String, each T))
   ) {
-    let components = String.labeledTupleComponents(
-      reflecting: labeledValues
-    )
+    var components: [String] = []
+    for labeledValue in repeat each labeledValues {
+      components.append("\(labeledValue.0): \(String(reflecting: labeledValue.1))")
+    }
     self = "(\(components.joined(separator: ", ")))"
   }
 
@@ -51,9 +55,10 @@ extension String {
     forConstructorOf type: Parent.Type,
     arguments labeledArguments: (repeat (String?, each T))
   ) {
-    let components = String.constructorArgumentComponents(
-      reflecting: labeledArguments
-    )
+    var components: [String] = []
+    for labeledArgument in repeat each labeledArguments {
+      components.append("\(labeledArgument.0.argumentLabelRepresentation)\(String(reflecting: labeledArgument.1))")
+    }
     self = "\(String(reflecting: type))(\(components.joined(separator: ", ")))"
   }
 
@@ -63,9 +68,10 @@ extension String {
     forConstructorOf type: Parent.Type,
     unlabeledArguments: (repeat each T)
   ) {
-    let components = String.tupleComponents(
-      reflecting: unlabeledArguments
-    )
+    var components: [String] = []
+    for value in repeat each unlabeledArguments {
+      components.append(String(reflecting: value))
+    }
     self = "\(String(reflecting: type))(\(components.joined(separator: ", ")))"
   }
 

--- a/Tests/MacroToolboxTests/Diagnostics/DiagnosticsSupport+Tests.swift
+++ b/Tests/MacroToolboxTests/Diagnostics/DiagnosticsSupport+Tests.swift
@@ -1,0 +1,363 @@
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacros
+import Testing
+@testable import MacroToolbox
+
+@Test("HDXL macro diagnostics preserve message identity and severity")
+func testHDXLMacroDiagnosticsPreserveMessageIdentityAndSeverity() {
+  // Hand-written examples: each factory should keep the supplied message ID and
+  // assign exactly the requested diagnostic severity.
+  let messageID = MessageID(domain: "ExampleDomain", id: "example")
+  let diagnostics = [
+    HDXLMacroDiagnostic.error("error message", diagnosticID: messageID),
+    HDXLMacroDiagnostic.warning("warning message", diagnosticID: messageID),
+    HDXLMacroDiagnostic.note("note message", diagnosticID: messageID),
+    HDXLMacroDiagnostic.remark("remark message", diagnosticID: messageID)
+  ]
+  
+  #expect(diagnostics.map(\.severity) == [.error, .warning, .note, .remark])
+  #expect(diagnostics.allSatisfy { $0.diagnosticID == messageID })
+  #expect(diagnostics[0].message == "error message")
+  #expect(diagnostics[0].description.contains("error"))
+  #expect(diagnostics[0].debugDescription.contains("HDXLMacroDiagnostic"))
+}
+
+@Test("HDXL macro diagnostic factories match direct construction")
+func testHDXLMacroDiagnosticFactoriesMatchDirectConstruction() {
+  // Property-style test: for every supported severity, the factory output should
+  // be equal to a directly constructed diagnostic with the same fields.
+  let messageID = MessageID(domain: "ExampleDomain", id: "factory")
+  let factories: [(DiagnosticSeverity, HDXLMacroDiagnostic)] = [
+    (.error, .error("message", diagnosticID: messageID)),
+    (.warning, .warning("message", diagnosticID: messageID)),
+    (.note, .note("message", diagnosticID: messageID)),
+    (.remark, .remark("message", diagnosticID: messageID))
+  ]
+  
+  for (severity, diagnostic) in factories {
+    #expect(
+      diagnostic
+      ==
+      HDXLMacroDiagnostic(
+        message: "message",
+        severity: severity,
+        diagnosticID: messageID
+      )
+    )
+  }
+}
+
+@Test("Macro diagnostic domains create diagnostics with the expected identity")
+func testMacroDiagnosticDomainsCreateDiagnosticsWithExpectedIdentity() throws {
+  // Hand-written examples: domain helpers should derive `MessageID` values from
+  // the domain type, and the diagnostic builder should preserve message, severity,
+  // highlights, notes, and fix-its on the resulting SwiftDiagnostics value.
+  let node = try StructDeclSyntax.onlyParsed(from: "struct Box {}")
+  let customID = ExampleDiagnosticDomain.messageID(id: "custom")
+  let defaultID = DefaultDiagnosticDomain.messageID(id: "default")
+  let diagnostic = ExampleDiagnosticDomain.diagnostic(
+    for: node,
+    explanation: "expected diagnostic",
+    severity: .warning,
+    messageID: "custom",
+    highlights: [Syntax(node)]
+  )
+  let thrownError = ExampleDiagnosticDomain.diagnosticError(
+    for: node,
+    explanation: "thrown diagnostic",
+    messageID: "thrown"
+  )
+  let publicSeverityDiagnostics = [
+    ExampleDiagnosticDomain.diagnosticWarning(
+      for: node,
+      explanation: "public warning",
+      messageID: "warning"
+    ),
+    ExampleDiagnosticDomain.diagnosticNote(
+      for: node,
+      explanation: "public note",
+      messageID: "note"
+    ),
+    ExampleDiagnosticDomain.diagnosticRemark(
+      for: node,
+      explanation: "public remark",
+      messageID: "remark"
+    )
+  ]
+  
+  #expect(ExampleDiagnosticDomain.diagnosticDomainIdentifier == "ExampleDiagnosticDomain")
+  #expect(customID == MessageID(domain: "ExampleDiagnosticDomain", id: "custom"))
+  #expect(DefaultDiagnosticDomain.diagnosticDomainIdentifier.contains("DefaultDiagnosticDomain"))
+  #expect(
+    defaultID
+    ==
+    MessageID(
+      domain: DefaultDiagnosticDomain.diagnosticDomainIdentifier,
+      id: "default"
+    )
+  )
+  #expect(String.standardMessageID == "diagnostic")
+  #expect(diagnostic.message == "expected diagnostic")
+  #expect(diagnostic.diagMessage.severity == .warning)
+  #expect(diagnostic.diagnosticID == customID)
+  #expect(diagnostic.highlights == [Syntax(node)])
+  #expect(thrownError.diagnostics.count == 1)
+  #expect(thrownError.diagnostics[0].diagMessage.severity == .error)
+  #expect(thrownError.diagnostics[0].diagnosticID == MessageID(domain: "ExampleDiagnosticDomain", id: "thrown"))
+  #expect(publicSeverityDiagnostics.map(\.diagMessage.severity) == [.warning, .note, .remark])
+  #expect(publicSeverityDiagnostics.map(\.diagnosticID) == [
+    MessageID(domain: "ExampleDiagnosticDomain", id: "warning"),
+    MessageID(domain: "ExampleDiagnosticDomain", id: "note"),
+    MessageID(domain: "ExampleDiagnosticDomain", id: "remark")
+  ])
+}
+
+@Test("Macro diagnostic domain severity builders agree with generic builder")
+func testMacroDiagnosticDomainSeverityBuildersAgreeWithGenericBuilder() throws {
+  // Property-style test: each package-level severity helper should be a thin
+  // wrapper over the generic diagnostic builder with the same node and message ID.
+  let node = try StructDeclSyntax.onlyParsed(from: "struct Box {}")
+  let builders: [(DiagnosticSeverity, Diagnostic)] = [
+    (
+      .error,
+      ExampleDiagnosticDomain._diagnosticError(
+        for: node,
+        explanation: "message",
+        messageID: "id"
+      )
+    ),
+    (
+      .warning,
+      ExampleDiagnosticDomain._diagnosticWarning(
+        for: node,
+        explanation: "message",
+        messageID: "id"
+      )
+    ),
+    (
+      .note,
+      ExampleDiagnosticDomain._diagnosticNote(
+        for: node,
+        explanation: "message",
+        messageID: "id"
+      )
+    ),
+    (
+      .remark,
+      ExampleDiagnosticDomain._diagnosticRemark(
+        for: node,
+        explanation: "message",
+        messageID: "id"
+      )
+    )
+  ]
+  
+  for (severity, diagnostic) in builders {
+    let generic = ExampleDiagnosticDomain.diagnostic(
+      for: node,
+      explanation: "message",
+      severity: severity,
+      messageID: "id"
+    )
+    
+    #expect(diagnostic.message == generic.message)
+    #expect(diagnostic.diagMessage.severity == severity)
+    #expect(diagnostic.diagnosticID == generic.diagnosticID)
+    #expect(diagnostic.node == generic.node)
+  }
+}
+
+@Test("Macro expansion failures preserve nested error context")
+func testMacroExpansionFailuresPreserveNestedErrorContext() {
+  // Hand-written examples: failures should retain explicit source coordinates,
+  // provide readable string/debug forms, and pretty-print both nested macro
+  // failures and ordinary errors.
+  let underlying = ExampleError(label: "underlying")
+  let base = MacroExpansionFailure(
+    explanation: "base failure",
+    suberrors: [underlying],
+    function: "expand()",
+    fileID: "Tests/Diagnostics.swift",
+    line: 12,
+    column: 3
+  )
+  let nested = base.encapsulated(
+    with: "outer failure",
+    function: "outer()",
+    fileID: "Tests/Outer.swift",
+    line: 20,
+    column: 5
+  )
+  let prettyPrinted = nested.prettyPrinted(indentation: "--", depth: 1)
+  
+  #expect(base.description.contains("base failure @ 12"))
+  #expect(base.debugDescription.contains("MacroExpansionFailure"))
+  #expect(nested.explanation == "outer failure")
+  #expect(nested.suberrors.count == 2)
+  #expect(prettyPrinted.contains("outer failure"))
+  #expect(prettyPrinted.contains("base failure"))
+  #expect(prettyPrinted.contains("ExampleError"))
+  #expect(prettyPrinted.contains("underlying"))
+}
+
+@Test("Macro expansion failure automatic encapsulation handles success and errors")
+func testMacroExpansionFailureAutomaticEncapsulationHandlesSuccessAndErrors() throws {
+  // Property-style test: automatic encapsulation should return successful results,
+  // rethrow macro expansion failures unchanged, and wrap other errors once.
+  let value = try MacroExpansionFailure.withAutomaticEncapsulation(explanation: "unused") {
+    "success"
+  }
+  let existing = MacroExpansionFailure(explanation: "existing")
+  
+  #expect(value == "success")
+  
+  do {
+    _ = try MacroExpansionFailure.withAutomaticEncapsulation(explanation: "wrapper") {
+      throw existing
+    }
+    Issue.record("Expected existing MacroExpansionFailure to be rethrown")
+  } catch let failure as MacroExpansionFailure {
+    #expect(failure.explanation == "existing")
+    #expect(failure.suberrors.isEmpty)
+  }
+  
+  do {
+    _ = try MacroExpansionFailure.withAutomaticEncapsulation(explanation: "wrapper") {
+      throw ExampleError(label: "plain")
+    }
+    Issue.record("Expected plain error to be wrapped")
+  } catch let failure as MacroExpansionFailure {
+    #expect(failure.explanation == "wrapper")
+    #expect(failure.suberrors.count == 1)
+  }
+}
+
+@Test("Diagnostic string interpolation reindents multiline text")
+func testDiagnosticStringInterpolationReindentsMultilineText() {
+  // Hand-written examples: empty indentation should leave input unchanged, while
+  // explicit indentation and depth-based indentation should prefix every line.
+  #expect("\(reindenting: "first\nsecond", with: "")" == "first\nsecond")
+  #expect("\(reindenting: "first\nsecond", with: "  ")" == "  first\n  second")
+  #expect("\(reindenting: "first\nsecond", indentation: ">", depth: 2)" == ">>first\n>>second")
+}
+
+@Test("Macro expansion context diagnostic conveniences record expected diagnostics")
+func testMacroExpansionContextDiagnosticConveniencesRecordExpectedDiagnostics() throws {
+  // Hand-written examples: optional and sequence diagnostics should only record
+  // concrete diagnostics, and `recordDiagnostic` should build an HDXL diagnostic
+  // anchored to the subject node when one is supplied.
+  let node = try StructDeclSyntax.onlyParsed(from: "struct Box { var value: Int }")
+  let subjectNode = try #require(node.memberBlock.firstSyntaxElement(ofType: VariableDeclSyntax.self))
+  let context = RecordingMacroExpansionContext()
+  let diagnostic = ExampleDiagnosticDomain.diagnostic(
+    for: node,
+    explanation: "first",
+    severity: .warning,
+    messageID: "first"
+  )
+  
+  context.diagnose(possibleDiagnostic: nil)
+  context.diagnose(possibleDiagnostic: diagnostic)
+  context.diagnose(diagnostics: [diagnostic, diagnostic])
+  context.diagnose(possibleDiagnostics: Optional([diagnostic]))
+  
+  let noDiagnostics: [Diagnostic]? = nil
+  context.diagnose(possibleDiagnostics: noDiagnostics)
+  context.recordDiagnostic(
+    attributionNode: node,
+    subjectNode: subjectNode,
+    severity: .error,
+    domainID: "RecordedDomain",
+    messageID: "recorded",
+    explanation: "recorded message",
+    highlights: [Syntax(subjectNode)]
+  )
+  
+  #expect(context.diagnostics.count == 5)
+  #expect(context.diagnostics.last?.message == "recorded message")
+  #expect(context.diagnostics.last?.diagMessage.severity == .error)
+  #expect(context.diagnostics.last?.diagnosticID == MessageID(domain: "RecordedDomain", id: "recorded"))
+  #expect(context.diagnostics.last?.position == subjectNode.positionAfterSkippingLeadingTrivia)
+  #expect(context.diagnostics.last?.highlights == [Syntax(subjectNode)])
+}
+
+@Test("Macro expansion context source-location strategy uses explicit or automatic locations")
+func testMacroExpansionContextSourceLocationStrategyUsesExplicitOrAutomaticLocations() throws {
+  // Property-style test: explicit source-location strategies should return the
+  // supplied location directly, while automatic strategies should delegate to the
+  // macro expansion context with the strategy's requested position and file mode.
+  let node = try StructDeclSyntax.onlyParsed(from: "struct Box {}")
+  let context = RecordingMacroExpansionContext()
+  let explicitLocation = AbstractSourceLocation(
+    SourceLocation(line: 2, column: 3, offset: 1, file: "explicit.swift")
+  )
+  let explicitResult = context.abstractSourceLocation(
+    attributionNode: node,
+    position: .explicit(explicitLocation)
+  )
+  let automaticResult = context.abstractSourceLocation(
+    attributionNode: node,
+    position: .standard
+  )
+  let customResult = context.abstractSourceLocation(
+    attributionNode: node,
+    position: .automatic(
+      AbstractSourceLocationStrategy(
+        positionInSyntaxNode: .afterTrailingTrivia,
+        filePathMode: .fileID
+      )
+    )
+  )
+  
+  #expect(explicitResult?.file.description.contains("explicit.swift") == true)
+  #expect(automaticResult?.file.description.contains("automatic.swift") == true)
+  #expect(customResult?.line.description == "9")
+  #expect(context.locationRequests.map(\.position) == [.afterLeadingTrivia, .afterTrailingTrivia])
+  #expect(context.locationRequests.map(\.filePathMode) == [.filePath, .fileID])
+}
+
+private enum ExampleDiagnosticDomain: MacroDiagnosticDomain {
+  static let diagnosticDomainIdentifier = "ExampleDiagnosticDomain"
+}
+
+private enum DefaultDiagnosticDomain: MacroDiagnosticDomain {}
+
+private struct ExampleError: Error, CustomDebugStringConvertible {
+  var label: String
+  
+  var debugDescription: String {
+    "ExampleError(\(label))"
+  }
+}
+
+private final class RecordingMacroExpansionContext: MacroExpansionContext {
+  var diagnostics: [Diagnostic] = []
+  var locationRequests: [(position: PositionInSyntaxNode, filePathMode: SourceLocationFilePathMode)] = []
+  var lexicalContext: [Syntax] = []
+  
+  func makeUniqueName(_ name: String) -> TokenSyntax {
+    .identifier("__\(name)")
+  }
+  
+  func diagnose(_ diagnostic: Diagnostic) {
+    diagnostics.append(diagnostic)
+  }
+  
+  func location(
+    of node: some SyntaxProtocol,
+    at position: PositionInSyntaxNode,
+    filePathMode: SourceLocationFilePathMode
+  ) -> AbstractSourceLocation? {
+    locationRequests.append((position, filePathMode))
+    
+    return AbstractSourceLocation(
+      SourceLocation(
+        line: locationRequests.count == 1 ? 7 : 9,
+        column: locationRequests.count == 1 ? 8 : 10,
+        offset: locationRequests.count,
+        file: "automatic.swift"
+      )
+    )
+  }
+}

--- a/Tests/MacroToolboxTests/Generation/GenerationSupport+Tests.swift
+++ b/Tests/MacroToolboxTests/Generation/GenerationSupport+Tests.swift
@@ -1,0 +1,210 @@
+import SwiftBasicFormat
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import Testing
+@testable import MacroToolbox
+
+@Test("Stored property declarations render modifiers, attributes, and initializers")
+func testStoredPropertyDeclarationsRenderModifiersAttributesAndInitializers() throws {
+  // Hand-written examples: stored-property generation should include attributes,
+  // isolation, public visibility, independent setter visibility, type, and initial
+  // value in the emitted variable declaration.
+  let property = StoredProperty(
+    name: "value",
+    typeName: "Int",
+    visibility: .public,
+    setterVisibility: .private,
+    isolation: .nonisolated,
+    attributes: ["@usableFromInline"],
+    initialValueExpression: "42"
+  )
+  let syntax = try property.makeSyntaxRepresentation()
+  
+  #expect(property.visibilityDeclaration == "public")
+  #expect(property.setterVisibilityDeclaration == "private(set)")
+  #expect(property.isolationDeclaration == "nonisolated")
+  #expect(property.modifierDeclaration == "nonisolated public private(set)")
+  #expect(property.attributeDeclaration == "@usableFromInline")
+  #expect(syntax.trimmedDescription == "@usableFromInline\nnonisolated public private(set) var value: Int = 42")
+  #expect(try property.makeDeclSyntax().trimmedDescription == syntax.trimmedDescription)
+}
+
+@Test("Stored property declaration defaults omit optional syntax")
+func testStoredPropertyDeclarationDefaultsOmitOptionalSyntax() throws {
+  // Property-style test: independent combinations of visibility, setter
+  // visibility, isolation, attributes, and initializers should render only the
+  // pieces that are present.
+  let samples: [(StoredProperty, [String], [String])] = [
+    (
+      StoredProperty(name: "plain", typeName: "String"),
+      ["var plain: String"],
+      ["nonisolated", "(set)", "="]
+    ),
+    (
+      StoredProperty(name: "configured", typeName: "Bool", setterVisibility: .fileprivate),
+      ["fileprivate(set) var configured: Bool"],
+      ["public", "nonisolated", "="]
+    ),
+    (
+      StoredProperty(name: "initialized", typeName: "Double", attributes: ["@MainActor"], initialValueExpression: "1.0"),
+      ["@MainActor", "var initialized: Double = 1.0"],
+      ["nonisolated", "(set)"]
+    )
+  ]
+  
+  for (property, includedFragments, excludedFragments) in samples {
+    let rendered = try property.makeSyntaxRepresentation().trimmedDescription
+    
+    for fragment in includedFragments {
+      #expect(rendered.contains(fragment))
+    }
+    for fragment in excludedFragments {
+      #expect(!rendered.contains(fragment))
+    }
+  }
+}
+
+@Test("Generation builders collect stored properties and foreach declarations")
+func testGenerationBuildersCollectStoredPropertiesAndForEachDeclarations() throws {
+  // Hand-written examples: the result-builder pieces should collect stored
+  // properties directly, flatten component arrays, and evaluate `ForEach` into
+  // declaration syntax values.
+  let first = StoredProperty(name: "first", typeName: "Int")
+  let second = StoredProperty(name: "second", typeName: "String")
+  let repeated = ForEach(source: [1, 2]) { index in
+    [
+      DeclSyntax(
+        try! VariableDeclSyntax("var generated\(raw: index): Int")
+      )
+    ]
+  }
+  let storedComponent = DataTypeBodyBuilder.buildExpression(first)
+  let repeatedComponent = DataTypeBodyBuilder.buildExpression(repeated)
+  let combined = DataTypeBodyBuilder.buildBlock(
+    storedComponent,
+    DataTypeBodyBuilder.buildExpression(second),
+    repeatedComponent
+  )
+  
+  #expect(storedComponent.count == 1)
+  #expect(repeated.evaluate().map(\.trimmedDescription) == ["var generated1: Int", "var generated2: Int"])
+  #expect(combined.count == 4)
+  #expect(try combined.map { try $0.makeDeclSyntax().trimmedDescription } == [
+    "var first: Int",
+    "var second: String",
+    "var generated1: Int",
+    "var generated2: Int"
+  ])
+}
+
+@Test("Declaration syntax wrappers validate and erase generated declarations")
+func testDeclarationSyntaxWrappersValidateAndEraseGeneratedDeclarations() throws {
+  // Property-style test: concrete SwiftSyntax declarations, `DeclSyntax`, and
+  // custom concrete declaration wrappers should all erase to the same validated
+  // declaration text used by member-block generation.
+  let variable = try VariableDeclSyntax("var value: Int")
+  let erased = try variable.makeDeclSyntax()
+  let existingDeclSyntax = try erased.makeDeclSyntax()
+  let generated = try StoredProperty(name: "name", typeName: "String").makeDeclSyntax()
+  let memberBlock = MemberBlockSyntax(declarations: [variable, generated.as(VariableDeclSyntax.self)!])
+  
+  #expect(erased.trimmedDescription == "var value: Int")
+  #expect(existingDeclSyntax.trimmedDescription == "var value: Int")
+  #expect(generated.trimmedDescription == "var name: String")
+  #expect(memberBlock.members.map { $0.decl.trimmedDescription } == ["var value: Int", "var name: String"])
+}
+
+@Test("Generic and inheritance generation helpers insert trailing commas correctly")
+func testGenericAndInheritanceGenerationHelpersInsertTrailingCommasCorrectly() {
+  // Hand-written examples: inheritance and generic where-clause helpers should
+  // produce comma-separated syntax without a trailing comma on the final element.
+  let inheritedTypes = InheritedTypeListSyntax.forTypeNames(["Base", "Sendable", "Codable"])
+  let inheritanceClause = InheritanceClauseSyntax.forInheritedTypeNames(["Base", "Sendable"])
+  let requirement = GenericRequirementSyntax.requirement(that: "Element", inheritsFrom: "Sendable")
+  let whereClause = GenericWhereClauseSyntax(requirements: [
+    requirement,
+    .requirement(that: "Value", inheritsFrom: "Codable")
+  ])
+  
+  #expect(inheritedTypes.trimmedDescription == "Base, Sendable, Codable")
+  #expect(inheritanceClause.trimmedDescription == ": Base, Sendable")
+  #expect(requirement.trimmedDescription == "Element: Sendable")
+  #expect(whereClause.trimmedDescription == "where Element: Sendable, Value: Codable")
+}
+
+@Test("Generic where clauses cover cartesian product generation")
+func testGenericWhereClausesCoverCartesianProductGeneration() {
+  // Property-style test: cartesian-product helpers should visit every ordered pair
+  // exactly once, and the failably-transformed variant should omit nil results.
+  let leftTypes = ["A", "B"]
+  let rightTypes = ["Sendable", "Codable"]
+  let fullProduct = GenericWhereClauseSyntax.withTransformedCartesianProduct(
+    of: (leftTypes, rightTypes)
+  ) { left, right in
+    GenericRequirementSyntax.requirement(that: left, inheritsFrom: right)
+  }
+  let filteredProduct = GenericWhereClauseSyntax.withFailablyTransformedCartesianProduct(
+    of: (leftTypes, rightTypes)
+  ) { left, right in
+    guard right == "Sendable" else { return nil }
+    return GenericRequirementSyntax.requirement(that: left, inheritsFrom: right)
+  }
+  
+  #expect(fullProduct.trimmedDescription == "where A: Sendable, A: Codable, B: Sendable, B: Codable")
+  #expect(fullProduct.requirements.map(\.trimmedDescription) == [
+    "A: Sendable,",
+    "A: Codable,",
+    "B: Sendable,",
+    "B: Codable"
+  ])
+  #expect(filteredProduct.trimmedDescription == "where A: Sendable, B: Sendable")
+  #expect(filteredProduct.requirements.map(\.trimmedDescription) == [
+    "A: Sendable,",
+    "B: Sendable"
+  ])
+}
+
+@Test("Autoformatting helpers preserve syntax shape")
+func testAutoformattingHelpersPreserveSyntaxShape() throws {
+  // Hand-written examples: current autoformatting intentionally returns the same
+  // syntax shape, but the wrapper APIs should still call through and preserve
+  // single syntax values and sequences.
+  let variable = try VariableDeclSyntax("var value: Int")
+  let function = try FunctionDeclSyntax("func run(){}")
+  let formattedVariable = try autoformattedEquivalent(of: variable)
+  let formattedFunction = try withAutomaticReformatting {
+    function
+  }
+  let formattedSequence: [VariableDeclSyntax] = try withAutomaticReformatting {
+    [
+      try VariableDeclSyntax("var first: Int"),
+      try VariableDeclSyntax("var second: String")
+    ]
+  }
+  
+  _ = BasicFormat.hdxlProjectFormatting(
+    initialIndentation: .spaces(2),
+    viewMode: .sourceAccurate
+  )
+  _ = BasicFormat.hdxlProjectFormatting()
+  let validatedVariable = try variable.validated()
+  
+  #expect(formattedVariable.trimmedDescription == "var value: Int")
+  #expect(validatedVariable.trimmedDescription == "var value: Int")
+  #expect(formattedFunction.trimmedDescription == "func run(){}")
+  #expect(formattedSequence.map(\.trimmedDescription) == ["var first: Int", "var second: String"])
+}
+
+@Test("Syntax collection comma insertion handles empty, single, and multiple elements")
+func testSyntaxCollectionCommaInsertionHandlesEmptySingleAndMultipleElements() {
+  // Property-style test: collections with comma-bearing elements should never add
+  // a trailing comma to the final element, and should add commas between every
+  // adjacent pair.
+  let empty = InheritedTypeListSyntax.forTypeNames([])
+  let single = InheritedTypeListSyntax.forTypeNames(["Only"])
+  let multiple = InheritedTypeListSyntax.forTypeNames(["First", "Second", "Third"])
+  
+  #expect(empty.trimmedDescription.isEmpty)
+  #expect(single.trimmedDescription == "Only")
+  #expect(multiple.trimmedDescription == "First, Second, Third")
+}

--- a/Tests/MacroToolboxTests/Introspection/Support/DataTypeMemberIntrospection+Tests.swift
+++ b/Tests/MacroToolboxTests/Introspection/Support/DataTypeMemberIntrospection+Tests.swift
@@ -1,0 +1,731 @@
+import SwiftSyntax
+import Testing
+@testable import MacroToolbox
+
+@Test("Variable declarations classify stored-property shapes")
+func testVariableDeclarationsClassifyStoredPropertyShapes() throws {
+  // Hand-written examples: the stored-property detector should accept plain
+  // stored declarations and observing accessors, but reject multi-bindings,
+  // getter-only computed properties, and non-identifier patterns.
+  let sourceFile = try SourceFileSyntax.onlyParsed(
+    from: """
+    struct Fixture {
+      var stored: Int
+      var multiA = 1, multiB = 2
+      var tuplePattern: (Int, Int) {
+        get { (1, 2) }
+      }
+      var observed: Int {
+        willSet {}
+        didSet {}
+      }
+      var computed: Int {
+        get { 1 }
+      }
+      var shorthandComputed: Int { 1 }
+      var (x, y): (Int, Int)
+    }
+    """
+  )
+  let declarations = sourceFile.variableDeclarationsByFirstIdentifier()
+
+  #expect(declarations["stored"]?.isStoredProperty == true)
+  #expect(declarations["stored"]?.variableNameIfStoredProperty == "stored")
+  #expect(declarations["multiA"]?.isStoredProperty == false)
+  #expect(declarations["multiA"]?.variableNameIfStoredProperty == nil)
+  #expect(declarations["observed"]?.isStoredProperty == true)
+  #expect(declarations["observed"]?.variableNameIfStoredProperty == "observed")
+  #expect(declarations["computed"]?.isStoredProperty == false)
+  #expect(declarations["computed"]?.variableNameIfStoredProperty == nil)
+  #expect(declarations["shorthandComputed"]?.isStoredProperty == false)
+  #expect(declarations["shorthandComputed"]?.variableNameIfStoredProperty == nil)
+  
+  let tuplePattern = try #require(
+    sourceFile.allSyntaxElements(ofType: VariableDeclSyntax.self).first {
+      $0.bindings.first?.pattern.as(TuplePatternSyntax.self) != nil
+    }
+  )
+  #expect(tuplePattern.isStoredProperty)
+  #expect(tuplePattern.variableNameIfStoredProperty == nil)
+}
+
+@Test("Variable stored-property classification agrees with descriptor construction")
+func testVariableStoredPropertyClassificationAgreesWithDescriptorConstruction() throws {
+  // Property-style test: for a range of declaration shapes, a stored-property
+  // descriptor should exist exactly when the variable is stored and has a
+  // simple identifier name.
+  let sourceFile = try SourceFileSyntax.onlyParsed(
+    from: """
+    struct Fixture {
+      var stored: Int
+      let constant: String
+      var observed: Int {
+        willSet {}
+        didSet {}
+      }
+      var computed: Int {
+        get { 1 }
+      }
+      var multiA = 1, multiB = 2
+      var (x, y): (Int, Int)
+    }
+    """
+  )
+  
+  for declaration in sourceFile.allSyntaxElements(ofType: VariableDeclSyntax.self) {
+    let expectedName = declaration.expectedStoredPropertyName
+    let descriptor = StoredPropertyDescriptor(variableDeclaration: declaration)
+    
+    #expect(declaration.variableNameIfStoredProperty == expectedName)
+    #expect((descriptor != nil) == (expectedName != nil))
+    #expect(descriptor?.storage.variableName == expectedName)
+  }
+}
+
+@Test("Member blocks expose typed declarations and stored properties")
+func testMemberBlocksExposeTypedDeclarationsAndStoredProperties() throws {
+  // Hand-written examples: member-block helpers should find declarations by
+  // concrete syntax type, filter them with predicates, and derive stored
+  // property descriptors only from stored property declarations.
+  let structure = try StructDeclSyntax.onlyParsed(
+    from: """
+    struct Fixture {
+      var first: Int
+      var second: String
+      var computed: Int { get { 1 } }
+      func run() {}
+      enum Nested { case value }
+    }
+    """
+  )
+  let members = structure.memberBlock.members
+  
+  #expect(Array(structure.memberBlock.allDeclarations(ofType: VariableDeclSyntax.self)).count == 3)
+  #expect(Array(members.allDeclarations(ofType: FunctionDeclSyntax.self)).count == 1)
+  #expect(
+    structure.memberBlock
+      .allSatisfactoryDeclarations(ofType: VariableDeclSyntax.self) {
+        $0.variableNameIfStoredProperty?.hasPrefix("s") == true
+      }
+      .map(\.variableNameIfStoredProperty)
+    ==
+    ["second"]
+  )
+  #expect(
+    members
+      .allSatisfactoryDeclarations(ofType: VariableDeclSyntax.self) {
+        $0.variableNameIfStoredProperty != nil
+      }
+      .map(\.variableNameIfStoredProperty)
+    ==
+    ["first", "second"]
+  )
+  #expect(
+    structure.memberBlock.predicateHoldsForAllDeclarations(
+      ofType: FunctionDeclSyntax.self
+    ) {
+      $0.name.text == "run"
+    }
+  )
+  #expect(
+    !members.predicateHoldsForAllDeclarations(
+      ofType: VariableDeclSyntax.self
+    ) {
+      $0.variableNameIfStoredProperty != nil
+    }
+  )
+  #expect(structure.memberBlock.storedPropertyDescriptors.map(\.storage.variableName) == ["first", "second"])
+  #expect(
+    structure.memberBlock
+      .allStoredPropertyDescriptors { $0.storage.variableName == "second" }
+      .map(\.storage.variableName)
+    ==
+    ["second"]
+  )
+}
+
+@Test("Member-block declaration helpers agree with standard collection operations")
+func testMemberBlockDeclarationHelpersAgreeWithStandardCollectionOperations() throws {
+  // Property-style test: across several type declarations, the convenience
+  // helpers should match the same compact-map, filter, and allSatisfy logic
+  // written directly over the member list.
+  let sourceFile = try SourceFileSyntax.onlyParsed(
+    from: """
+    struct StructFixture {
+      var first: Int
+      var computed: Int { get { 1 } }
+      func run() {}
+    }
+    class ClassFixture {
+      var first: Int
+      var second: String
+      convenience init() { self.init(value: 0) }
+      init(value: Int) { self.first = value; self.second = "" }
+    }
+    actor ActorFixture {
+      var first: Int
+      func run() {}
+    }
+    """
+  )
+  
+  for declaration in sourceFile.allSyntaxElements(ofType: StructDeclSyntax.self) {
+    assertMemberBlockProperties(declaration.memberBlock)
+  }
+  for declaration in sourceFile.allSyntaxElements(ofType: ClassDeclSyntax.self) {
+    assertMemberBlockProperties(declaration.memberBlock)
+  }
+  for declaration in sourceFile.allSyntaxElements(ofType: ActorDeclSyntax.self) {
+    assertMemberBlockProperties(declaration.memberBlock)
+  }
+}
+
+@Test("Data type declarations forward generic and stored-property helpers")
+func testDataTypeDeclarationsForwardGenericAndStoredPropertyHelpers() throws {
+  // Hand-written examples: struct, class, and actor declarations should expose
+  // their generic parameter names and stored-property descriptors through the
+  // declaration-specific forwarding conveniences.
+  let sourceFile = try SourceFileSyntax.onlyParsed(
+    from: """
+    struct StructBox<T> {
+      var value: T
+      var computed: Int { get { 1 } }
+    }
+    class ClassBox<Element> {
+      var value: Element
+      convenience init() { self.init(value: fatalError()) }
+      required init(value: Element) { self.value = value }
+    }
+    actor ActorBox<State> {
+      var state: State
+    }
+    """
+  )
+  let structure = try #require(sourceFile.firstSyntaxElement(ofType: StructDeclSyntax.self))
+  let classDecl = try #require(sourceFile.firstSyntaxElement(ofType: ClassDeclSyntax.self))
+  let actor = try #require(sourceFile.firstSyntaxElement(ofType: ActorDeclSyntax.self))
+  
+  #expect(structure.simpleGenericParameterNames == ["T"])
+  #expect(structure.storedPropertyDescriptors.map(\.storage.variableName) == ["value"])
+  #expect(structure.allStoredPropertyDescriptors { $0.storage.variableName == "value" }.count == 1)
+  #expect(classDecl.simpleGenericParameterNames == ["Element"])
+  #expect(classDecl.storedPropertyDescriptors.map(\.storage.variableName) == ["value"])
+  #expect(classDecl.allStoredPropertyDescriptors { $0.storage.variableName == "value" }.count == 1)
+  #expect(classDecl.preferredDesignatedInitializerDeclarationIfAvailable?.signature.description.contains("value: Element") == true)
+  #expect(actor.simpleGenericParameterNames == ["State"])
+  #expect(actor.storedPropertyDescriptors.map(\.storage.variableName) == ["state"])
+  #expect(actor.allStoredPropertyDescriptors { $0.storage.variableName == "state" }.count == 1)
+}
+
+@Test("Data type declaration helpers agree with member-block helpers")
+func testDataTypeDeclarationHelpersAgreeWithMemberBlockHelpers() throws {
+  // Property-style test: for each supported data-type declaration, forwarded
+  // stored-property helpers should equal the result from its own member block.
+  let sourceFile = try SourceFileSyntax.onlyParsed(
+    from: """
+    struct StructBox<T> {
+      var value: T
+    }
+    class ClassBox<Element> {
+      var value: Element
+      init(value: Element) { self.value = value }
+    }
+    actor ActorBox<State> {
+      var state: State
+    }
+    """
+  )
+  
+  for structure in sourceFile.allSyntaxElements(ofType: StructDeclSyntax.self) {
+    #expect(structure.simpleGenericParameterNames == structure.genericParameterClause?.simpleGenericParameterNames)
+    #expect(structure.storedPropertyDescriptors == structure.memberBlock.storedPropertyDescriptors)
+    #expect(
+      structure.allStoredPropertyDescriptors { $0.storage.variableName.hasSuffix("e") }
+      ==
+      structure.memberBlock.allStoredPropertyDescriptors { $0.storage.variableName.hasSuffix("e") }
+    )
+  }
+  for classDecl in sourceFile.allSyntaxElements(ofType: ClassDeclSyntax.self) {
+    #expect(classDecl.simpleGenericParameterNames == classDecl.genericParameterClause?.simpleGenericParameterNames)
+    #expect(classDecl.storedPropertyDescriptors == classDecl.memberBlock.storedPropertyDescriptors)
+    #expect(
+      classDecl.allStoredPropertyDescriptors { $0.storage.variableName.hasSuffix("e") }
+      ==
+      classDecl.memberBlock.allStoredPropertyDescriptors { $0.storage.variableName.hasSuffix("e") }
+    )
+  }
+  for actor in sourceFile.allSyntaxElements(ofType: ActorDeclSyntax.self) {
+    #expect(actor.simpleGenericParameterNames == actor.genericParameterClause?.simpleGenericParameterNames)
+    #expect(actor.storedPropertyDescriptors == actor.memberBlock.storedPropertyDescriptors)
+    #expect(
+      actor.allStoredPropertyDescriptors { $0.storage.variableName.hasSuffix("e") }
+      ==
+      actor.memberBlock.allStoredPropertyDescriptors { $0.storage.variableName.hasSuffix("e") }
+    )
+  }
+}
+
+@Test("Initializer helpers identify preferred and plausible memberwise initializers")
+func testInitializerHelpersIdentifyPreferredAndPlausibleMemberwiseInitializers() throws {
+  // Hand-written examples: preferred initializers are detected by attribute, and
+  // plausible memberwise matching accepts both labeled and unlabeled parameters
+  // that correspond to stored property names.
+  let sourceFile = try SourceFileSyntax.onlyParsed(
+    from: """
+    struct Fixture {
+      var first: Int
+      var second: String
+      @PreferredMemberwiseInitializer
+      init(first: Int, _ second: String) {
+        self.first = first
+        self.second = second
+      }
+      init(first: Int) {
+        self.first = first
+        self.second = ""
+      }
+    }
+    """
+  )
+  let structure = try #require(sourceFile.firstSyntaxElement(ofType: StructDeclSyntax.self))
+  let initializers = sourceFile.allSyntaxElements(ofType: InitializerDeclSyntax.self)
+  let preferred = try #require(initializers.first)
+  let incomplete = try #require(initializers.dropFirst().first)
+  let storedProperties = Array(structure.memberBlock.allDeclarations(ofType: VariableDeclSyntax.self))
+  
+  #expect(preferred.isPreferredMemberwiseInitializer)
+  #expect(preferred.isPlausibleMemberwiseInitializer(forStoredProperties: storedProperties))
+  #expect(!incomplete.isPreferredMemberwiseInitializer)
+  #expect(!incomplete.isPlausibleMemberwiseInitializer(forStoredProperties: storedProperties))
+}
+
+@Test("Initializer plausibility matches stored-property name coverage")
+func testInitializerPlausibilityMatchesStoredPropertyNameCoverage() throws {
+  // Property-style test: an initializer is plausible exactly when its parameter
+  // name set covers every simple stored-property name and the counts match.
+  let fixtures: [(source: String, expected: Bool)] = [
+    (
+      """
+      struct Fixture {
+        var value: Int
+        init(value: Int) {}
+      }
+      """,
+      true
+    ),
+    (
+      """
+      struct Fixture {
+        var value: Int
+        init(_ value: Int) {}
+      }
+      """,
+      true
+    ),
+    (
+      """
+      struct Fixture {
+        var value: Int
+        var other: Int
+        init(value: Int) {}
+      }
+      """,
+      false
+    ),
+    (
+      """
+      struct Fixture {
+        var (x, y): (Int, Int)
+        init(value: (Int, Int)) {}
+      }
+      """,
+      false
+    )
+  ]
+  
+  for fixture in fixtures {
+    let structure = try StructDeclSyntax.onlyParsed(from: fixture.source)
+    let initializer = try #require(structure.memberBlock.allDeclarations(ofType: InitializerDeclSyntax.self).first)
+    let storedProperties = Array(structure.memberBlock.allDeclarations(ofType: VariableDeclSyntax.self))
+    
+    #expect(
+      initializer.isPlausibleMemberwiseInitializer(forStoredProperties: storedProperties)
+      ==
+      fixture.expected
+    )
+  }
+}
+
+@Test("Class preferred initializer chooses required or designated initializers")
+func testClassPreferredInitializerChoosesRequiredOrDesignatedInitializers() throws {
+  // Hand-written examples: classes without initializers or with only convenience
+  // initializers have no preferred designated initializer, while designated and
+  // required initializers are accepted candidates.
+  let noInitializer = try ClassDeclSyntax.onlyParsed(from: "class Empty {}")
+  let convenienceOnly = try ClassDeclSyntax.onlyParsed(
+    from: "class ConvenienceOnly { convenience init() { self.init() } }"
+  )
+  let designated = try ClassDeclSyntax.onlyParsed(
+    from: "class Designated { init(value: Int) {} convenience init() { self.init(value: 0) } }"
+  )
+  let required = try ClassDeclSyntax.onlyParsed(
+    from: "class Required { required convenience init(value: Int) { self.init() } init() {} }"
+  )
+  
+  #expect(noInitializer.preferredDesignatedInitializerDeclarationIfAvailable == nil)
+  #expect(convenienceOnly.preferredDesignatedInitializerDeclarationIfAvailable == nil)
+  #expect(
+    designated.preferredDesignatedInitializerDeclarationIfAvailable?
+      .signature
+      .parameterClause
+      .parameters
+      .first?
+      .firstName
+      .text
+    ==
+    "value"
+  )
+  #expect(
+    required.preferredDesignatedInitializerDeclarationIfAvailable?
+      .modifiers
+      .contains { $0.name.text == "required" }
+    ==
+    true
+  )
+}
+
+@Test("Class preferred initializer matches filtering rule")
+func testClassPreferredInitializerMatchesFilteringRule() throws {
+  // Property-style test: the class convenience should return the first parsed
+  // initializer that is required or not convenience, matching the documented
+  // filtering rule used by the implementation.
+  let classes = try SourceFileSyntax.onlyParsed(
+    from: """
+    class Empty {}
+    class ConvenienceOnly {
+      convenience init() { self.init() }
+    }
+    class Designated {
+      convenience init() { self.init(value: 0) }
+      init(value: Int) {}
+    }
+    class Required {
+      required convenience init(value: Int) { self.init() }
+      init() {}
+    }
+    """
+  ).allSyntaxElements(ofType: ClassDeclSyntax.self)
+  
+  for classDecl in classes {
+    let expected = classDecl.memberBlock.members
+      .compactMap { $0.decl.as(InitializerDeclSyntax.self) }
+      .filter { initializer in
+        let isRequired = initializer.modifiers.contains { $0.name.text == "required" }
+        let isConvenience = initializer.modifiers.contains { $0.name.text == "convenience" }
+        return isRequired || !isConvenience
+      }
+      .first
+    
+    #expect(classDecl.preferredDesignatedInitializerDeclarationIfAvailable == expected)
+  }
+}
+
+@Test("Declaration archetype helpers map concrete declaration types")
+func testDeclarationArchetypeHelpersMapConcreteDeclarationTypes() throws {
+  // Hand-written examples: declaration mapping should return the matching model
+  // value for concrete declarations and nil for declarations outside a mapping.
+  let structure = try StructDeclSyntax.onlyParsed(from: "struct Fixture { var value: Int }")
+  let genericStructure = try StructDeclSyntax.onlyParsed(from: "struct GenericFixture<Value> {}")
+  let variable = try VariableDeclSyntax.onlyParsed(from: "let value = 1")
+  
+  #expect(structure.typeDeclarationArchetype == .struct)
+  #expect(variable.typeDeclarationArchetype == nil)
+  #expect(variable.declarationArchetype == .variable)
+  #expect(
+    structure.applyConcreteTypeMapping(
+      associations: (
+        ("class", ClassDeclSyntax.self),
+        ("struct", StructDeclSyntax.self)
+      )
+    )
+    ==
+    "struct"
+  )
+  #expect(
+    structure.applyConcreteTypeMapping(
+      associations: (
+        ("struct", StructDeclSyntax.self),
+        ("class", ClassDeclSyntax.self)
+      )
+    )
+    ==
+    "struct"
+  )
+  #expect(
+    variable.applyConcreteTypeMapping(
+      associations: (
+        ("struct", StructDeclSyntax.self),
+        ("class", ClassDeclSyntax.self)
+      )
+    )
+    ==
+    nil
+  )
+  // Empty associations are legal and should behave like "no matching type"; this
+  // guards the variadic-pack loop's zero-element path.
+  let emptyMapping: String? = structure.applyConcreteTypeMapping(associations: ())
+  #expect(emptyMapping == nil)
+  
+  // A matched optional value still counts as the first match even when that
+  // value is nil; later duplicate associations must not replace it.
+  let nilOptionalMapping: String?? = structure.applyConcreteTypeMapping(
+    associations: (
+      (String?.none, StructDeclSyntax.self),
+      (String?.some("fallback"), StructDeclSyntax.self)
+    )
+  )
+  #expect(nilOptionalMapping.map { $0 == nil } == true)
+  #expect(
+    structure.extractHomogeneousValues(
+      using: (
+        (\StructDeclSyntax.name, StructDeclSyntax.self),
+        (\ClassDeclSyntax.name, ClassDeclSyntax.self)
+      )
+    )?
+      .text
+    ==
+    "Fixture"
+  )
+  #expect(
+    variable.extractHomogeneousValues(
+      using: (
+        (\StructDeclSyntax.name, StructDeclSyntax.self),
+        (\VariableDeclSyntax.bindingSpecifier, VariableDeclSyntax.self)
+      )
+    )?
+      .text
+    ==
+    "let"
+  )
+  #expect(
+    structure.extractHomogeneousValues(
+      using: (
+        (\StructDeclSyntax.genericParameterClause, StructDeclSyntax.self),
+        (\ClassDeclSyntax.genericParameterClause, ClassDeclSyntax.self)
+      )
+    )
+    ==
+    nil
+  )
+  #expect(
+    genericStructure.extractHomogeneousValues(
+      using: (
+        (\StructDeclSyntax.genericParameterClause, StructDeclSyntax.self),
+        (\ClassDeclSyntax.genericParameterClause, ClassDeclSyntax.self)
+      )
+    )?
+      .trimmedDescription
+    ==
+    "<Value>"
+  )
+  
+  let missingRequiredExtraction: TokenSyntax? = variable.extractHomogeneousValues(
+    using: (
+      (\StructDeclSyntax.name, StructDeclSyntax.self),
+      (\ClassDeclSyntax.name, ClassDeclSyntax.self)
+    )
+  )
+  let missingOptionalExtraction: GenericParameterClauseSyntax? = variable.extractHomogeneousValues(
+    using: (
+      (\StructDeclSyntax.genericParameterClause, StructDeclSyntax.self),
+      (\ClassDeclSyntax.genericParameterClause, ClassDeclSyntax.self)
+    )
+  )
+  
+  #expect(missingRequiredExtraction == nil)
+  #expect(missingOptionalExtraction == nil)
+}
+
+@Test("Declaration archetype helpers agree with SwiftSyntax casting")
+func testDeclarationArchetypeHelpersAgreeWithSwiftSyntaxCasting() throws {
+  // Property-style test: for a representative set of declarations, the model
+  // archetypes should agree with the declaration's concrete SwiftSyntax type.
+  let sourceFile = try SourceFileSyntax.onlyParsed(
+    from: """
+    import Foundation
+    #sourceLocation(file: "Fixture.swift", line: 10)
+    public actor Worker {}
+    final class Box {
+      init() {}
+      deinit {}
+      subscript(index: Int) -> Int { index }
+      var value: Int { 0 }
+      func run() {}
+    }
+    enum Choice { case one }
+    extension Choice {}
+    protocol Service { associatedtype Output }
+    struct Pair {}
+    typealias Alias = Int
+    operator infix +++
+    precedencegroup CustomPrecedence {}
+    macro generated() = #externalMacro(module: "M", type: "T")
+    #if os(macOS)
+    let conditional = true
+    #endif
+    let value = 1
+    """
+  )
+  let macroExpansion = MacroExpansionDeclSyntax(
+    macroName: .identifier("expand"),
+    arguments: []
+  )
+  let expectedTypeArchetypes: [(any DeclSyntaxProtocol, TypeDeclarationArchetype?)] = [
+    (try #require(sourceFile.firstSyntaxElement(ofType: ActorDeclSyntax.self)), .actor),
+    (try #require(sourceFile.firstSyntaxElement(ofType: ClassDeclSyntax.self)), .class),
+    (try #require(sourceFile.firstSyntaxElement(ofType: EnumDeclSyntax.self)), .enum),
+    (try #require(sourceFile.firstSyntaxElement(ofType: ProtocolDeclSyntax.self)), .protocol),
+    (try #require(sourceFile.firstSyntaxElement(ofType: StructDeclSyntax.self)), .struct),
+    (try #require(sourceFile.firstSyntaxElement(ofType: VariableDeclSyntax.self)), nil)
+  ]
+  let expectedDeclarationArchetypes: [(any DeclSyntaxProtocol, DeclarationArchetype)] = [
+    (try #require(sourceFile.firstSyntaxElement(ofType: ActorDeclSyntax.self)), .actor),
+    (try #require(sourceFile.firstSyntaxElement(ofType: AssociatedTypeDeclSyntax.self)), .associatedtype),
+    (try #require(sourceFile.firstSyntaxElement(ofType: ClassDeclSyntax.self)), .class),
+    (try #require(sourceFile.firstSyntaxElement(ofType: DeinitializerDeclSyntax.self)), .deinitializer),
+    (try #require(sourceFile.firstSyntaxElement(ofType: EnumCaseDeclSyntax.self)), .enumCase),
+    (try #require(sourceFile.firstSyntaxElement(ofType: EnumDeclSyntax.self)), .enum),
+    (try #require(sourceFile.firstSyntaxElement(ofType: ExtensionDeclSyntax.self)), .extension),
+    (try #require(sourceFile.firstSyntaxElement(ofType: FunctionDeclSyntax.self)), .function),
+    (try #require(sourceFile.firstSyntaxElement(ofType: IfConfigDeclSyntax.self)), .ifConfig),
+    (try #require(sourceFile.firstSyntaxElement(ofType: ImportDeclSyntax.self)), .import),
+    (try #require(sourceFile.firstSyntaxElement(ofType: InitializerDeclSyntax.self)), .initializer),
+    (try #require(sourceFile.firstSyntaxElement(ofType: MacroDeclSyntax.self)), .macro),
+    (macroExpansion, .macroExpansion),
+    (try #require(sourceFile.firstSyntaxElement(ofType: OperatorDeclSyntax.self)), .operator),
+    (try #require(sourceFile.firstSyntaxElement(ofType: PoundSourceLocationSyntax.self)), .poundSourceLocation),
+    (try #require(sourceFile.firstSyntaxElement(ofType: PrecedenceGroupDeclSyntax.self)), .precedenceGroup),
+    (try #require(sourceFile.firstSyntaxElement(ofType: ProtocolDeclSyntax.self)), .protocol),
+    (try #require(sourceFile.firstSyntaxElement(ofType: StructDeclSyntax.self)), .struct),
+    (try #require(sourceFile.firstSyntaxElement(ofType: SubscriptDeclSyntax.self)), .subscript),
+    (try #require(sourceFile.firstSyntaxElement(ofType: TypeAliasDeclSyntax.self)), .typealias),
+    (try #require(sourceFile.firstSyntaxElement(ofType: VariableDeclSyntax.self)), .variable)
+  ]
+  
+  for (declaration, expected) in expectedTypeArchetypes {
+    #expect(declaration.typeDeclarationArchetype == expected)
+  }
+  
+  for (declaration, expected) in expectedDeclarationArchetypes {
+    #expect(declaration.declarationArchetype == expected)
+  }
+}
+
+private func assertMemberBlockProperties(
+  _ memberBlock: MemberBlockSyntax
+) {
+  let members = memberBlock.members
+  let variables = members.compactMap { $0.decl.as(VariableDeclSyntax.self) }
+  let storedNames = variables.compactMap(\.variableNameIfStoredProperty)
+  let expectedStoredDescriptors = variables.compactMap {
+    StoredPropertyDescriptor(variableDeclaration: $0)
+  }
+  let expectedFunctionNames = members
+    .compactMap { $0.decl.as(FunctionDeclSyntax.self) }
+    .map(\.name.text)
+  
+  #expect(Array(memberBlock.allDeclarations(ofType: VariableDeclSyntax.self)) == variables)
+  #expect(Array(members.allDeclarations(ofType: VariableDeclSyntax.self)) == variables)
+  #expect(memberBlock.storedPropertyDescriptors == expectedStoredDescriptors)
+  #expect(memberBlock.storedPropertyDescriptors.map(\.storage.variableName) == storedNames)
+  #expect(
+    memberBlock.allStoredPropertyDescriptors { $0.storage.variableName.hasPrefix("f") }
+    ==
+    expectedStoredDescriptors.filter { $0.storage.variableName.hasPrefix("f") }
+  )
+  #expect(
+    memberBlock
+      .allSatisfactoryDeclarations(ofType: FunctionDeclSyntax.self) { _ in true }
+      .map(\.name.text)
+    ==
+    expectedFunctionNames
+  )
+  #expect(
+    members
+      .allSatisfactoryDeclarations(ofType: VariableDeclSyntax.self) {
+        $0.variableNameIfStoredProperty != nil
+      }
+    ==
+    variables.filter { $0.variableNameIfStoredProperty != nil }
+  )
+  #expect(
+    memberBlock.predicateHoldsForAllDeclarations(
+      ofType: VariableDeclSyntax.self
+    ) {
+      $0.bindings.count == 1
+    }
+    ==
+    variables.allSatisfy { $0.bindings.count == 1 }
+  )
+  #expect(
+    members.predicateHoldsForAllDeclarations(
+      ofType: FunctionDeclSyntax.self
+    ) {
+      !$0.name.text.isEmpty
+    }
+    ==
+    members.compactMap { $0.decl.as(FunctionDeclSyntax.self) }.allSatisfy {
+      !$0.name.text.isEmpty
+    }
+  )
+}
+
+private extension SourceFileSyntax {
+  
+  func variableDeclarationsByFirstIdentifier() -> [String: VariableDeclSyntax] {
+    Dictionary(
+      uniqueKeysWithValues: allSyntaxElements(ofType: VariableDeclSyntax.self).compactMap { declaration in
+        guard
+          let identifier = declaration.bindings.first?.pattern.as(IdentifierPatternSyntax.self)
+        else {
+          return nil
+        }
+        
+        return (identifier.identifier.text, declaration)
+      }
+    )
+  }
+  
+}
+
+private extension VariableDeclSyntax {
+  
+  var expectedStoredPropertyName: String? {
+    guard
+      bindings.count == 1,
+      let binding = bindings.first,
+      binding.hasAccessorsCompatibleWithStoredProperty,
+      let identifier = binding.pattern.as(IdentifierPatternSyntax.self)
+    else {
+      return nil
+    }
+    
+    return identifier.identifier.trimmed.text
+  }
+  
+}
+
+private extension PatternBindingSyntax {
+  
+  var hasAccessorsCompatibleWithStoredProperty: Bool {
+    switch accessorBlock?.accessors {
+    case .none:
+      true
+    case .some(.getter):
+      false
+    case .some(.accessors(let accessors)):
+      accessors.allSatisfy(\.isCompatibleWithStoredProperty)
+    }
+  }
+  
+}

--- a/Tests/MacroToolboxTests/Introspection/Support/SyntaxIntrospectionSupport+Tests.swift
+++ b/Tests/MacroToolboxTests/Introspection/Support/SyntaxIntrospectionSupport+Tests.swift
@@ -1,0 +1,399 @@
+import SwiftSyntax
+import Testing
+@testable import MacroToolbox
+
+@Test("Literal syntax value helpers")
+func testLiteralSyntaxValueHelpers() throws {
+  // Hand-written examples: each literal helper should return the represented
+  // Swift value for a straightforward literal and nil for a token that is not
+  // actually that literal kind.
+  #expect(
+    BooleanLiteralExprSyntax(literal: .keyword(.true)).representedBooleanLiteralValue
+    ==
+    true
+  )
+  #expect(
+    BooleanLiteralExprSyntax(literal: .keyword(.false)).representedBooleanLiteralValue
+    ==
+    false
+  )
+  #expect(
+    BooleanLiteralExprSyntax(literal: .identifier("flag")).representedBooleanLiteralValue
+    ==
+    nil
+  )
+  
+  #expect(
+    try FloatLiteralExprSyntax
+      .firstParsed(from: "let value = 1.25")
+      .representedFloatLiteralValue
+    ==
+    1.25
+  )
+  #expect(FloatLiteralExprSyntax(literal: .identifier("value")).representedFloatLiteralValue == nil)
+  
+  #expect(
+    try IntegerLiteralExprSyntax
+      .firstParsed(from: "let value = 42")
+      .representedIntegerLiteralValue
+    ==
+    42
+  )
+  #expect(
+    try IntegerLiteralExprSyntax
+      .firstParsed(from: "let value = 42")
+      .representedValue(ofType: UInt8.self)
+    ==
+    42
+  )
+  #expect(IntegerLiteralExprSyntax(literal: .identifier("value")).representedIntegerLiteralValue == nil)
+  #expect(IntegerLiteralExprSyntax(literal: .identifier("value")).representedValue(ofType: UInt8.self) == nil)
+  
+  #expect(
+    simpleStringLiteral(["hel", "lo"]).representedStringLiteralValue
+    ==
+    "hello"
+  )
+}
+
+@Test("Literal syntax value helpers match token payloads")
+func testLiteralSyntaxValueHelpersMatchTokenPayloads() throws {
+  // Property-style test: across several literal spellings, the helper result
+  // must match Swift's own numeric parsing or the literal token's known meaning.
+  for value in [true, false] {
+    let syntax = BooleanLiteralExprSyntax(
+      literal: .keyword(value ? .true : .false)
+    )
+    
+    #expect(syntax.representedBooleanLiteralValue == value)
+  }
+  
+  for value in ["0.0", "3.5", "2.25"] {
+    let syntax = try FloatLiteralExprSyntax.firstParsed(from: "let value = \(value)")
+    #expect(syntax.representedFloatLiteralValue == Double(value))
+  }
+  
+  for value in ["0", "7", "255"] {
+    let syntax = try IntegerLiteralExprSyntax.firstParsed(from: "let value = \(value)")
+    #expect(syntax.representedIntegerLiteralValue == Int(value))
+    #expect(syntax.representedValue(ofType: UInt16.self) == UInt16(value))
+  }
+  
+  for value in ["", "a", "hello"] {
+    let syntax = simpleStringLiteral([value])
+    #expect(syntax.representedStringLiteralValue == value)
+  }
+}
+
+@Test("Token and keyword predicate helpers")
+func testTokenAndKeywordPredicateHelpers() {
+  // Hand-written examples: token-kind and token-syntax predicates should
+  // recognize the common plus/minus operator spellings and accessor keywords.
+  #expect(TokenKind.prefixOperator("-").isPrefixMinusSign)
+  #expect(TokenKind.prefixOperator("+").isPrefixPlusSign)
+  #expect(TokenKind.binaryOperator("-").isInfixMinusSign)
+  #expect(TokenKind.binaryOperator("+").isInfixPlusSign)
+  #expect(TokenKind.postfixOperator("!").isPostfixOperator("!"))
+  #expect(TokenSyntax.prefixOperator("-").isPrefixOperator("-"))
+  #expect(TokenSyntax.postfixOperator("!").isPostfixOperator("!"))
+  #expect(TokenSyntax.binaryOperator("*").isInfixOperator("*"))
+  #expect(TokenSyntax.prefixOperator("-").isPrefixMinusSign)
+  #expect(TokenSyntax.prefixOperator("+").isPrefixPlusSign)
+  #expect(TokenSyntax.keyword(.willSet).isWillSet)
+  #expect(TokenSyntax.keyword(.didSet).isDidSet)
+  #expect(TokenSyntax.keyword(.get).isGet)
+  #expect(TokenSyntax.keyword(.set).isSet)
+  #expect(TokenSyntax.keyword(._modify).isModify)
+  #expect(TokenSyntax.keyword(.public).keyword == .public)
+}
+
+@Test("Token and keyword predicate helpers match exact token kinds")
+func testTokenAndKeywordPredicateHelpersMatchExactTokenKinds() {
+  // Property-style test: operator predicates are exact spelling checks, and
+  // visibility keywords should round-trip through the `VisibilityLevel` model.
+  for operatorSymbol in ["+", "-", "*"] {
+    #expect(TokenKind.prefixOperator(operatorSymbol).isPrefixOperator(operatorSymbol))
+    #expect(TokenKind.binaryOperator(operatorSymbol).isInfixOperator(operatorSymbol))
+    #expect(TokenKind.postfixOperator(operatorSymbol).isPostfixOperator(operatorSymbol))
+  }
+  
+  for visibilityLevel in VisibilityLevel.allCases {
+    let keyword = visibilityLevel.keywordRepresentation
+    
+    #expect(keyword.visibilityLevel == visibilityLevel)
+    #expect(TokenSyntax.keyword(keyword).keyword == keyword)
+  }
+  
+  #expect(Keyword.func.visibilityLevel == nil)
+  #expect(TokenSyntax.identifier("value").keyword == nil)
+}
+
+@Test("Attribute and accessor syntax helpers")
+func testAttributeAndAccessorSyntaxHelpers() throws {
+  // Hand-written examples: named attributes, inlinability attributes, argument
+  // lists, and accessor keyword classifications are all read from parsed Swift
+  // syntax rather than from manually assembled partial nodes.
+  let sourceFile = try SourceFileSyntax.onlyParsed(
+    from: """
+    @inlinable
+    @PreferredMemberwiseInitializer
+    @objc(run)
+    public init() {}
+    struct Box {
+      var observed: Int {
+        willSet {}
+        didSet {}
+      }
+      var computed: Int {
+        get { 1 }
+        set {}
+      }
+    }
+    """
+  )
+  let attributes = try #require(
+    sourceFile.firstSyntaxElement(ofType: InitializerDeclSyntax.self)?.attributes
+  )
+  let conditionalFunction = try FunctionDeclSyntax.onlyParsed(
+    from: """
+    #if os(macOS)
+    @inlinable
+    #endif
+    func conditional() {}
+    """
+  )
+  let conditionalAttributeElement = try #require(conditionalFunction.attributes.first)
+  let preferredAttribute = try #require(
+    attributes.first { $0.isPreferredMemberwiseInitializer }?.attributeSyntax
+  )
+  let argumentListAttribute = AttributeSyntax(
+    attributeName: IdentifierTypeSyntax.forType(named: "Example"),
+    leftParen: .leftParenToken(),
+    arguments: .argumentList([]),
+    rightParen: .rightParenToken()
+  )
+  let qualifiedAttribute = AttributeSyntax("@Module.Attribute")
+  let accessors = sourceFile.allSyntaxElements(ofType: AccessorDeclSyntax.self)
+  
+  #expect(attributes.containsAttribute(named: "inlinable"))
+  #expect(attributes.inlinabilityDisposition == .inlinable)
+  #expect(attributes.nonConfigurationAttributes.count == 3)
+  #expect(!conditionalAttributeElement.isAttribute(named: "inlinable"))
+  #expect(conditionalAttributeElement.attributeSyntax == nil)
+  #expect(conditionalAttributeElement.inlinabilityDisposition == nil)
+  #expect(!conditionalAttributeElement.isPreferredMemberwiseInitializer)
+  #expect(conditionalFunction.attributes.nonConfigurationAttributes.isEmpty)
+  #expect(preferredAttribute.hasAtSign)
+  #expect(preferredAttribute.hasNoArguments)
+  #expect(preferredAttribute.isPreferredMemberwiseInitializer)
+  #expect(preferredAttribute.argumentListAsLabeledExprList == nil)
+  #expect(!argumentListAttribute.hasNoArguments)
+  #expect(argumentListAttribute.argumentListAsLabeledExprList != nil)
+  #expect(qualifiedAttribute.inlinabilityDisposition == nil)
+  #expect(!qualifiedAttribute.hasName("Attribute"))
+  #expect(accessors.contains { $0.isWillSet && $0.isCompatibleWithStoredProperty })
+  #expect(accessors.contains { $0.isDidSet && $0.isCompatibleWithStoredProperty })
+  #expect(accessors.contains { $0.isGet && $0.isIncompatibleWithStoredProperty })
+  #expect(accessors.contains { $0.isSet && $0.isIncompatibleWithStoredProperty })
+}
+
+@Test("Accessor list compatibility follows member compatibility")
+func testAccessorListCompatibilityFollowsMemberCompatibility() throws {
+  // Property-style test: an accessor list is stored-property-compatible exactly
+  // when none of its accessors is individually incompatible.
+  let sourceFile = try SourceFileSyntax.onlyParsed(
+    from: """
+    struct Box {
+      var observed: Int {
+        willSet {}
+        didSet {}
+      }
+      var computed: Int {
+        get { 1 }
+        set {}
+      }
+    }
+    """
+  )
+  
+  for accessorList in sourceFile.allSyntaxElements(ofType: AccessorDeclListSyntax.self) {
+    let hasIncompatibleAccessor = accessorList.contains {
+      $0.isIncompatibleWithStoredProperty
+    }
+    
+    #expect(accessorList.isIncompatibleWithStoredProperty == hasIncompatibleAccessor)
+    #expect(accessorList.isCompatibleWithStoredProperty == !hasIncompatibleAccessor)
+  }
+}
+
+@Test("Generic name extraction helpers")
+func testGenericNameExtractionHelpers() throws {
+  // Hand-written examples: simple generic parameter and argument lists should
+  // return just their identifier names, while parameter packs are not simple.
+  let sourceFile = try SourceFileSyntax.onlyParsed(
+    from: """
+    struct Pair<First, Second> {}
+    struct Pack<each Element> {}
+    let value: Pair<Int, String>
+    """
+  )
+  let pair = try #require(sourceFile.firstSyntaxElement(ofType: StructDeclSyntax.self))
+  let pack = try #require(
+    sourceFile
+      .allSyntaxElements(ofType: StructDeclSyntax.self)
+      .first { $0.name.text == "Pack" }
+  )
+  let argumentClause = try #require(
+    sourceFile.firstSyntaxElement(ofType: GenericArgumentClauseSyntax.self)
+  )
+  
+  #expect(pair.simpleGenericParameterNames == ["First", "Second"])
+  #expect(pack.simpleGenericParameterNames == nil)
+  #expect(argumentClause.simpleGenericParameterNames == ["Int", "String"])
+}
+
+@Test("Generic name extraction helpers require all names to be simple")
+func testGenericNameExtractionHelpersRequireAllNamesToBeSimple() throws {
+  // Property-style test: declarations and type arguments with only identifier
+  // names produce a full name list; introducing a non-simple member makes the
+  // aggregate helper return nil rather than a partial result.
+  let simpleStruct = try StructDeclSyntax.onlyParsed(from: "struct Box<T, U> {}")
+  let packStruct = try StructDeclSyntax.onlyParsed(from: "struct Box<each T> {}")
+  let publicActor = try ActorDeclSyntax.onlyParsed(from: "@inlinable public actor Worker<State> {}")
+  let genericEnum = try EnumDeclSyntax.onlyParsed(from: "enum Choice<Value> { case value(Value) }")
+  let genericClass = try ClassDeclSyntax.onlyParsed(from: "class Box<Element> {}")
+  let simpleArguments = try GenericArgumentClauseSyntax.firstParsed(
+    from: "let value: Box<Int, String>"
+  )
+  let nonSimpleArguments = try GenericArgumentClauseSyntax.firstParsed(
+    from: "let value: Box<[Int]>"
+  )
+  let declGroups: [any DeclGroupSyntax] = [
+    publicActor,
+    genericEnum,
+    genericClass,
+    simpleStruct
+  ]
+  
+  #expect(simpleStruct.genericParameterClause?.parameters.simpleGenericParameterNames == ["T", "U"])
+  #expect(packStruct.genericParameterClause?.parameters.simpleGenericParameterNames == nil)
+  #expect(simpleArguments.arguments.simpleGenericParameterNames == ["Int", "String"])
+  #expect(nonSimpleArguments.arguments.simpleGenericParameterNames == nil)
+  #expect(declGroups.map(\.visibilityLevel) == [.public, nil, nil, nil])
+  #expect(declGroups.map(\.inlinabilityDisposition) == [.inlinable, nil, nil, nil])
+  #expect(declGroups.compactMap(\.simpleGenericParameterNames) == [["State"], ["Value"], ["Element"], ["T", "U"]])
+}
+
+@Test("Enum case syntax helpers")
+func testEnumCaseSyntaxHelpers() throws {
+  // Hand-written examples: single payload-free cases expose their identifier,
+  // while payload or multi-case declarations are not treated as simple cases.
+  let sourceFile = try SourceFileSyntax.onlyParsed(
+    from: """
+    enum Choice {
+      @available(macOS 14.0, *)
+      case first
+      case second(Int)
+      case third, fourth
+    }
+    """
+  )
+  let cases = sourceFile.allSyntaxElements(ofType: EnumCaseDeclSyntax.self)
+  let first = try #require(cases.first)
+  let second = try #require(cases.dropFirst().first)
+  let multi = try #require(cases.dropFirst(2).first)
+  let emptyElements = EnumCaseElementListSyntax([])
+  
+  #expect(first.isSimpleCaseWithoutPayload)
+  #expect(first.primarySourceCodeIdentifier?.text == "first")
+  #expect(first.hasAttribute(named: "available"))
+  #expect(!second.isSimpleCaseWithoutPayload)
+  #expect(second.primarySourceCodeIdentifier?.text == "second")
+  #expect(!multi.isSimpleCaseWithoutPayload)
+  #expect(multi.primarySourceCodeIdentifier == nil)
+  #expect(!emptyElements.isSimpleCaseWithoutPayload)
+  #expect(emptyElements.primarySourceCodeIdentifier == nil)
+}
+
+@Test("Enum declaration case helpers filter and quantify cases")
+func testEnumDeclarationCaseHelpersFilterAndQuantifyCases() throws {
+  // Property-style test: enum-level helpers should agree with the equivalent
+  // standard-library operations over parsed case declarations.
+  let simpleEnum = try EnumDeclSyntax.onlyParsed(from: "enum Choice { case first; case second }")
+  let mixedEnum = try EnumDeclSyntax.onlyParsed(from: "enum Choice { case first; case second(Int) }")
+  
+  for enumDecl in [simpleEnum, mixedEnum] {
+    let cases = Array(enumDecl.memberBlock.allDeclarations(ofType: EnumCaseDeclSyntax.self))
+    
+    #expect(enumDecl.allCasesAreSimpleWithoutPayload == cases.allSatisfy(\.isSimpleCaseWithoutPayload))
+    #expect(
+      Array(enumDecl.allCaseDeclarationsSatisfying(\.isSimpleCaseWithoutPayload)).map(\.description)
+      ==
+      cases.filter(\.isSimpleCaseWithoutPayload).map(\.description)
+    )
+  }
+}
+
+@Test("Member access syntax helpers")
+func testMemberAccessSyntaxHelpers() throws {
+  // Hand-written examples: `.none` is recognized only as an argumentless member
+  // access named `none`, and type-level property access allows omitted bases or
+  // a base matching the requested type name.
+  let none = try MemberAccessExprSyntax.onlyParsed(from: "let value = Optional<Int>.none")
+  let implicit = try MemberAccessExprSyntax.onlyParsed(from: "let value = .value")
+  let matching = try MemberAccessExprSyntax.onlyParsed(from: "let value = Int.value")
+  let mismatching = try MemberAccessExprSyntax.onlyParsed(from: "let value = String.value")
+  let callBase = try MemberAccessExprSyntax.onlyParsed(from: "let value = Int().value")
+  let methodReference = try MemberAccessExprSyntax.onlyParsed(from: "let value = Int.method(label:)")
+  let argumentNameBase = try MemberAccessExprSyntax.onlyParsed(from: "let value = method(label:).value")
+  let keywordBase = try MemberAccessExprSyntax.onlyParsed(from: "let value = Self.value")
+  let selfAccess = try MemberAccessExprSyntax.onlyParsed(from: "let value = Int.self")
+  
+  #expect(none.isExplicitNone)
+  #expect(implicit.isCompatibleWithTypeLevelPropertyAccess(forBaseType: Int.self))
+  #expect(matching.isCompatibleWithTypeLevelPropertyAccess(forBaseType: Int.self))
+  #expect(!mismatching.isCompatibleWithTypeLevelPropertyAccess(forBaseType: Int.self))
+  #expect(!callBase.isCompatibleWithTypeLevelPropertyAccess(forBaseType: Int.self))
+  #expect(methodReference.isCompatibleWithTypeLevelPropertyAccess(forBaseType: Int.self))
+  #expect(!argumentNameBase.isCompatibleWithTypeLevelPropertyAccess(forBaseType: Int.self))
+  #expect(!keywordBase.isCompatibleWithTypeLevelPropertyAccess(forBaseType: Int.self))
+  #expect(!selfAccess.isExplicitNone)
+}
+
+@Test("Member access syntax helpers match accepted base-name sets")
+func testMemberAccessSyntaxHelpersMatchAcceptedBaseNameSets() throws {
+  // Property-style test: the set-based overload must accept exactly omitted
+  // bases or bases whose identifier appears in the accepted-name set.
+  let acceptedNames: Set<String> = ["Int"]
+  let samples: [(String, Bool)] = [
+    ("let value = .value", true),
+    ("let value = Int.value", true),
+    ("let value = String.value", false),
+    ("let value = Int().value", false),
+    ("let value = method(label:).value", false),
+    ("let value = Self.value", false)
+  ]
+  
+  for (source, expected) in samples {
+    let memberAccess = try MemberAccessExprSyntax.onlyParsed(from: source)
+    #expect(
+      memberAccess.isCompatibleWithTypeLevelPropertyAccess(forBaseTypeNames: acceptedNames)
+      ==
+      expected
+    )
+  }
+}
+
+private func simpleStringLiteral(
+  _ segments: [String]
+) -> SimpleStringLiteralExprSyntax {
+  SimpleStringLiteralExprSyntax(
+    openingQuote: .stringQuoteToken(),
+    segments: SimpleStringLiteralSegmentListSyntax(
+      segments.map {
+        StringSegmentSyntax(content: .stringSegment($0))
+      }
+    ),
+    closingQuote: .stringQuoteToken()
+  )
+}

--- a/Tests/MacroToolboxTests/MacroProtocols/MacroProtocolSupport+Tests.swift
+++ b/Tests/MacroToolboxTests/MacroProtocols/MacroProtocolSupport+Tests.swift
@@ -1,0 +1,724 @@
+import Foundation
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+import Testing
+@testable import MacroToolbox
+
+@Test("Macro contexts record diagnostics and enforce value requirements")
+func testMacroContextsRecordDiagnosticsAndEnforceValueRequirements() throws {
+  // Hand-written examples: successful requirements should return the underlying
+  // values unchanged, while failed requirements should throw and record one
+  // diagnostic through the expansion context.
+  let expansionContext = TestMacroExpansionContext()
+  let context = RequirementMacroContext(
+    macroInvocationNode: AttributeSyntax("@Requirement(value: 1)"),
+    expansionContext: expansionContext,
+    optionalSelfValue: 7,
+    selfSyntax: try ExprSyntax.onlyParsed(from: "1"),
+    optionalSelfSyntax: try ExprSyntax.onlyParsed(from: "2")
+  )
+  let source = RequirementSource(
+    optionalInt: 11,
+    optionalValues: ["first"],
+    values: ["second"],
+    optionalSyntax: try ExprSyntax.onlyParsed(from: "3"),
+    syntax: try ExprSyntax.onlyParsed(from: "4"),
+    optionalAny: "payload"
+  )
+  
+  #expect(try context.requireValue("explicit value") { 5 } == 5)
+  #expect(try context.requireValue("optional value") { Optional.some("value") } == "value")
+  #expect(try context.requireProperty(\.optionalSelfValue) == 7)
+  #expect(try context.requireProperty(\.optionalInt, of: source) == 11)
+  #expect(try context.requireNonEmptyProperty(\.optionalValues, of: source) == ["first"])
+  #expect(try context.requireNonEmptyProperty(\.values, of: source) == ["second"])
+  #expect(try context.requireSyntaxProperty(\.optionalSyntax, of: source, as: IntegerLiteralExprSyntax.self).literal.text == "3")
+  #expect(try context.requireSyntaxProperty(\.syntax, of: source, as: IntegerLiteralExprSyntax.self).literal.text == "4")
+  #expect(try context.requireSyntaxProperty(\.selfSyntax, as: IntegerLiteralExprSyntax.self).literal.text == "1")
+  #expect(try context.requireSyntaxProperty(\.optionalSelfSyntax, as: IntegerLiteralExprSyntax.self).literal.text == "2")
+  #expect(try context.requireProperty(\.optionalAny, of: source, as: String.self) == "payload")
+  #expect(try context.requireNonEmptyValues([1, 2, 3]) == [1, 2, 3])
+  #expect(try context.requireNonNull(Optional("nonnull")) == "nonnull")
+  try context.requireCondition("true condition") { true }
+  try context.requireThat(true)
+  #expect(expansionContext.diagnostics.isEmpty)
+  
+  let emptySource = RequirementSource(
+    optionalInt: nil,
+    optionalValues: [],
+    values: [],
+    optionalSyntax: nil,
+    syntax: try ExprSyntax.onlyParsed(from: "\"wrong\""),
+    optionalAny: 1
+  )
+  let wrongSyntaxSource = RequirementSource(
+    optionalInt: nil,
+    optionalValues: nil,
+    values: [],
+    optionalSyntax: try ExprSyntax.onlyParsed(from: "\"wrong\""),
+    syntax: try ExprSyntax.onlyParsed(from: "\"wrong\""),
+    optionalAny: 1
+  )
+  let nilAnySource = RequirementSource(
+    optionalInt: nil,
+    optionalValues: nil,
+    values: [],
+    optionalSyntax: nil,
+    syntax: try ExprSyntax.onlyParsed(from: "1"),
+    optionalAny: nil
+  )
+  let wrongSelfContext = RequirementMacroContext(
+    macroInvocationNode: AttributeSyntax("@Requirement"),
+    expansionContext: expansionContext,
+    optionalSelfValue: nil,
+    selfSyntax: try ExprSyntax.onlyParsed(from: "\"wrong\""),
+    optionalSelfSyntax: try ExprSyntax.onlyParsed(from: "\"wrong\"")
+  )
+  let failureOperations: [() throws -> Void] = [
+    { _ = try context.requireValue("throwing value") { throw ExampleMacroError(label: "plain") } },
+    { _ = try context.requireValue("throwing optional") { () throws -> Int? in
+      throw ExampleMacroError(label: "optional")
+    } },
+    { _ = try context.requireValue("missing optional") { Optional<Int>.none } },
+    { _ = try wrongSelfContext.requireProperty(\.optionalSelfValue) },
+    { _ = try context.requireProperty(\.optionalInt, of: emptySource) },
+    { _ = try context.requireNonEmptyProperty(\.optionalValues, of: wrongSyntaxSource) },
+    { _ = try context.requireNonEmptyProperty(\.optionalValues, of: emptySource) },
+    { _ = try context.requireNonEmptyProperty(\.values, of: emptySource) },
+    { _ = try context.requireSyntaxProperty(\.optionalSyntax, of: emptySource, as: IntegerLiteralExprSyntax.self) },
+    { _ = try context.requireSyntaxProperty(\.optionalSyntax, of: wrongSyntaxSource, as: IntegerLiteralExprSyntax.self) },
+    { _ = try context.requireSyntaxProperty(\.syntax, of: wrongSyntaxSource, as: IntegerLiteralExprSyntax.self) },
+    { _ = try wrongSelfContext.requireSyntaxProperty(\.selfSyntax, as: IntegerLiteralExprSyntax.self) },
+    { _ = try RequirementMacroContext(
+      macroInvocationNode: AttributeSyntax("@Requirement"),
+      expansionContext: expansionContext,
+      optionalSelfValue: nil,
+      selfSyntax: try ExprSyntax.onlyParsed(from: "1"),
+      optionalSelfSyntax: nil
+    ).requireSyntaxProperty(\.optionalSelfSyntax, as: IntegerLiteralExprSyntax.self) },
+    { _ = try wrongSelfContext.requireSyntaxProperty(\.optionalSelfSyntax, as: IntegerLiteralExprSyntax.self) },
+    { _ = try context.requireProperty(\.optionalAny, of: nilAnySource, as: String.self) },
+    { _ = try context.requireProperty(\.optionalAny, of: emptySource, as: String.self) },
+    { try context.requireCondition("false condition") { false } },
+    { try context.requireCondition("throwing condition") { throw ExampleMacroError(label: "condition") } },
+    { try context.requireThat(false) },
+    { _ = try context.requireNonEmptyValues([Int]()) },
+    { _ = try context.requireNonNull(Optional<Int>.none) }
+  ]
+  
+  for operation in failureOperations {
+    expectMacroExpansionFailure(operation)
+  }
+  #expect(expansionContext.diagnostics.count == failureOperations.count)
+  #expect(expansionContext.diagnostics.allSatisfy { $0.diagMessage.severity == .error })
+}
+
+@Test("Macro context diagnostic recording helpers preserve severity and defaults")
+func testMacroContextDiagnosticRecordingHelpersPreserveSeverityAndDefaults() throws {
+  // Property-style test: each severity convenience should delegate to the generic
+  // recorder with the same domain, message ID, fallback attribution node, and
+  // optional subject node.
+  let expansionContext = TestMacroExpansionContext()
+  let context = RequirementMacroContext(
+    macroInvocationNode: AttributeSyntax("@Requirement"),
+    expansionContext: expansionContext
+  )
+  let subjectNode = try ExprSyntax.onlyParsed(from: "value")
+  
+  context.recordDiagnostic(
+    severity: .error,
+    messageIdentifier: "generic",
+    explanation: "generic message",
+    subjectNode: subjectNode
+  )
+  context.recordError(messageIdentifier: "error", explanation: "error message")
+  context.recordWarning(messageIdentifier: "warning", explanation: "warning message")
+  context.recordNote(messageIdentifier: "note", explanation: "note message")
+  context.recordRemark(messageIdentifier: "remark", explanation: "remark message")
+  
+  #expect(expansionContext.diagnostics.map(\.diagMessage.severity) == [.error, .error, .warning, .note, .remark])
+  #expect(expansionContext.diagnostics.map(\.diagnosticID) == [
+    MessageID(domain: "RequirementDomain", id: "generic"),
+    MessageID(domain: "RequirementDomain", id: "error"),
+    MessageID(domain: "RequirementDomain", id: "warning"),
+    MessageID(domain: "RequirementDomain", id: "note"),
+    MessageID(domain: "RequirementDomain", id: "remark")
+  ])
+  #expect(expansionContext.diagnostics[0].node.trimmedDescription == "@Requirement")
+  #expect(expansionContext.diagnostics[0].position == subjectNode.positionAfterSkippingLeadingTrivia)
+  #expect(expansionContext.diagnostics[1].node.trimmedDescription == "@Requirement")
+  
+  expectMacroExpansionFailure {
+    try context.withAutomaticRecordingForRequiredOperation(
+      messageIdentifier: "automatic",
+      explanation: "automatic failure",
+      attributionNode: subjectNode,
+      subjectNode: subjectNode
+    ) {
+      throw MacroExpansionFailure(explanation: "inner")
+    }
+  }
+  #expect(expansionContext.diagnostics.last?.diagnosticID == MessageID(domain: "RequirementDomain", id: "automatic"))
+  #expect(expansionContext.diagnostics.last?.node.trimmedDescription == "value")
+}
+
+@Test("Attached macro contexts expose invocation, declaration, and member helpers")
+func testAttachedMacroContextsExposeInvocationDeclarationAndMemberHelpers() throws {
+  // Hand-written examples: attached context structs should preserve their captured
+  // inputs, derive invocation arguments from attribute syntax, and re-use the
+  // generic requirement helpers for declaration and member re-interpretation.
+  let expansionContext = TestMacroExpansionContext()
+  let attribute = AttributeSyntax("@Example(value: 1)")
+  let plainAttribute = AttributeSyntax("@Example")
+  let structDecl = try StructDeclSyntax.onlyParsed(from: "@inlinable public struct Box<T> { var value: T }")
+  let internalStructDecl = try StructDeclSyntax.onlyParsed(from: "struct InternalBox { var value: Int }")
+  let variableDecl = try VariableDeclSyntax.onlyParsed(from: "var value: Int")
+  let unsupportedDecl = try #require(
+    UnsupportedDeclSyntax(try ExprSyntax.onlyParsed(from: "1"))
+  )
+  let memberContext = MemberMacroContext(
+    macroInvocationNode: attribute,
+    declaration: structDecl,
+    conformedProtocols: [TypeSyntax(IdentifierTypeSyntax.forType(named: "Sendable"))],
+    expansionContext: expansionContext,
+    diagnosticDomainIdentifier: "AttachedDomain"
+  )
+  let internalMemberContext = MemberMacroContext(
+    macroInvocationNode: plainAttribute,
+    declaration: internalStructDecl,
+    conformedProtocols: [],
+    expansionContext: expansionContext,
+    diagnosticDomainIdentifier: "AttachedDomain"
+  )
+  let peerContext = PeerMacroContext(
+    macroInvocationNode: plainAttribute,
+    declaration: variableDecl,
+    expansionContext: expansionContext,
+    diagnosticDomainIdentifier: "AttachedDomain"
+  )
+  let unsupportedPeerContext = PeerMacroContext(
+    macroInvocationNode: plainAttribute,
+    declaration: unsupportedDecl,
+    expansionContext: expansionContext,
+    diagnosticDomainIdentifier: "AttachedDomain"
+  )
+  let memberAttributeContext = MemberAttributeMacroContext(
+    macroInvocationNode: attribute,
+    declaration: structDecl,
+    member: variableDecl,
+    expansionContext: expansionContext,
+    diagnosticDomainIdentifier: "AttachedDomain"
+  )
+  let typeMemberAttributeContext = MemberAttributeMacroContext(
+    macroInvocationNode: attribute,
+    declaration: structDecl,
+    member: structDecl,
+    expansionContext: expansionContext,
+    diagnosticDomainIdentifier: "AttachedDomain"
+  )
+  let unsupportedMemberAttributeContext = MemberAttributeMacroContext(
+    macroInvocationNode: attribute,
+    declaration: structDecl,
+    member: unsupportedDecl,
+    expansionContext: expansionContext,
+    diagnosticDomainIdentifier: "AttachedDomain"
+  )
+  
+  #expect(memberContext.invocationArgumentsAsLabeledExpressionList?.count == 1)
+  #expect(peerContext.invocationArgumentsAsLabeledExpressionList == nil)
+  #expect(memberContext.syntaxNodeForAttribution.trimmedDescription == "@Example(value: 1)")
+  #expect(memberContext.syntaxNodeForPositioning.trimmedDescription == "@Example(value: 1)")
+  #expect(memberContext.explicitVisibilityLevel == .public)
+  #expect(memberContext.visibilityLevel == .public)
+  #expect(internalMemberContext.explicitVisibilityLevel == nil)
+  #expect(internalMemberContext.visibilityLevel == .internal)
+  #expect(memberContext.inlinabilityDisposition == .inlinable)
+  #expect(memberContext.functionOrMethodGenerationDetails.0 == .public)
+  #expect(memberContext.conformedProtocols.map(\.trimmedDescription) == ["Sendable"])
+  #expect(try memberContext.requireDeclaration(as: StructDeclSyntax.self).name.text == "Box")
+  if case .struct(let concreteStruct) = try memberContext.requireConcreteDeclSyntax() {
+    #expect(concreteStruct.name.text == "Box")
+  } else {
+    Issue.record("Expected a concrete struct declaration")
+  }
+  #expect(try memberContext.requireConcreteTypeDeclaration().name == "Box")
+  if case .variable(let concreteVariable) = try memberAttributeContext.requireMemberAsConcreteDeclSyntax() {
+    #expect(concreteVariable.trimmedDescription == "var value: Int")
+  } else {
+    Issue.record("Expected a concrete variable declaration")
+  }
+  #expect(try typeMemberAttributeContext.requireMemberAsConcreteTypeDeclaration().name == "Box")
+  
+  expectMacroExpansionFailure {
+    _ = try peerContext.requireDeclaration(as: StructDeclSyntax.self)
+  }
+  expectMacroExpansionFailure {
+    _ = try peerContext.requireConcreteTypeDeclaration()
+  }
+  expectMacroExpansionFailure {
+    _ = try memberAttributeContext.requireMemberAsConcreteTypeDeclaration()
+  }
+  expectMacroExpansionFailure {
+    try peerContext.requireSatisfactoryAttachment(attachmentRequirement: .exactly(.struct))
+  }
+  expectMacroExpansionFailure {
+    try unsupportedPeerContext.requireSatisfactoryAttachment(
+      attachmentRequirement: .exactly(.struct)
+    )
+  }
+  expectMacroExpansionFailure {
+    _ = try unsupportedPeerContext.requireConcreteDeclSyntax()
+  }
+  expectMacroExpansionFailure {
+    _ = try unsupportedMemberAttributeContext.requireMemberAsConcreteDeclSyntax()
+  }
+  #expect(expansionContext.diagnostics.count == 7)
+  #expect(expansionContext.diagnostics.map(\.diagnosticID) == [
+    MessageID(domain: "AttachedDomain", id: .declarationOfIncorrectType),
+    MessageID(domain: "AttachedDomain", id: .declarationOfIncorrectType),
+    MessageID(domain: "AttachedDomain", id: .declarationOfIncorrectType),
+    MessageID(domain: "AttachedDomain", id: .attachedToExcludedArchetype),
+    MessageID(domain: "AttachedDomain", id: .requiredPropertyWasNil),
+    MessageID(domain: "AttachedDomain", id: .declarationOfIncorrectType),
+    MessageID(domain: "AttachedDomain", id: .declarationOfIncorrectType)
+  ])
+}
+
+@Test("Contextualized attached macro expansions validate and delegate")
+func testContextualizedAttachedMacroExpansionsValidateAndDelegate() throws {
+  // Property-style test: each attached macro role should create the expected context,
+  // run the default validators, and return the syntax emitted by the contextualized
+  // implementation.
+  let expansionContext = TestMacroExpansionContext()
+  let attribute = AttributeSyntax("@Default")
+  let variableDecl = try VariableDeclSyntax.onlyParsed(from: "var value: Int")
+  let functionDecl = try FunctionDeclSyntax.onlyParsed(from: "func value() -> Int { 1 }")
+  let structDecl = try StructDeclSyntax.onlyParsed(from: "struct Box { var value: Int }")
+  
+  let accessors = try DefaultAccessorMacro.expansion(
+    of: attribute,
+    providingAccessorsOf: variableDecl,
+    in: expansionContext
+  )
+  let body = try DefaultBodyMacro.expansion(
+    of: attribute,
+    providingBodyFor: functionDecl,
+    in: expansionContext
+  )
+  let members = try DefaultMemberMacro.expansion(
+    of: attribute,
+    providingMembersOf: structDecl,
+    conformingTo: [],
+    in: expansionContext
+  )
+  let attributes = try DefaultMemberAttributeMacro.expansion(
+    of: attribute,
+    attachedTo: structDecl,
+    providingAttributesFor: variableDecl,
+    in: expansionContext
+  )
+  let peers = try DefaultPeerMacro.expansion(
+    of: attribute,
+    providingPeersOf: variableDecl,
+    in: expansionContext
+  )
+  let markerPeers = try DefaultMarkerMacro.expansion(
+    of: attribute,
+    providingPeersOf: variableDecl,
+    in: expansionContext
+  )
+  
+  #expect(accessors.map(\.trimmedDescription) == ["get { value }"])
+  #expect(body.map(\.trimmedDescription) == ["return 1"])
+  #expect(members.map(\.trimmedDescription) == ["var generatedMember: Int"])
+  #expect(attributes.map(\.trimmedDescription) == ["@usableFromInline"])
+  #expect(peers.map(\.trimmedDescription) == ["typealias GeneratedPeer = Int"])
+  #expect(markerPeers.isEmpty)
+  #expect(DefaultDiagnosticMacro.diagnosticDomainIdentifier.contains("DefaultDiagnosticMacro"))
+  #expect(DefaultTypeAttachedMacro.typeAttachmentRequirement.isCompatible(with: .struct))
+  #expect(DefaultTypeAttachedMacro.attachmentRequirement.isCompatible(with: .struct))
+  #expect(!ProtocolIncompatibleMacro.typeAttachmentRequirement.isCompatible(with: .protocol))
+  
+  try DefaultPeerMacro.validateMacroInvocationName("Anything")
+  try DefaultPeerMacro.validateAttachedTypeName("Anything")
+  try RegexPeerMacro.validateMacroInvocationName("Allowed")
+  try RegexPeerMacro.validateAttachedTypeName("Box")
+  #expect(throws: ContextualizedAttachedMacroValidationError.self) {
+    try RegexPeerMacro.validateMacroInvocationName("Denied")
+  }
+  #expect(throws: ContextualizedAttachedMacroValidationError.self) {
+    try RegexPeerMacro.validateAttachedTypeName("Other")
+  }
+}
+
+@Test("Freestanding macro contexts and expansions preserve invocation arguments")
+func testFreestandingMacroContextsAndExpansionsPreserveInvocationArguments() throws {
+  // Hand-written examples: freestanding expression and declaration macros should
+  // expose their invocation arguments through the generated contexts and delegate
+  // expansion to the contextualized implementation.
+  let expansionContext = TestMacroExpansionContext()
+  let expressionInvocation = try MacroExpansionExprSyntax.onlyParsed(from: "#makeExpression(1, label: 2)")
+  let declarationInvocation = try MacroExpansionDeclSyntax("#makeDeclaration(label: 3)")
+  let expressionContext = ExpressionMacroContext(
+    macroInvocationNode: expressionInvocation,
+    expansionContext: expansionContext,
+    diagnosticDomainIdentifier: "FreestandingDomain"
+  )
+  
+  let expression = try DefaultExpressionMacro.expansion(
+    of: expressionInvocation,
+    in: expansionContext
+  )
+  let declarations = try DefaultDeclarationMacro.expansion(
+    of: declarationInvocation,
+    in: expansionContext
+  )
+  
+  #expect(expressionContext.invocationArgumentsAsLabeledExpressionList?.count == 2)
+  #expect(expression.trimmedDescription == "42")
+  #expect(declarations.map(\.trimmedDescription) == ["struct GeneratedDeclaration {}"])
+}
+
+@Test("Conditional and unconditional conformance macros render expected extensions")
+func testConditionalAndUnconditionalConformanceMacrosRenderExpectedExtensions() throws {
+  // Property-style test: conformance macro helpers should combine generic parameters,
+  // implicit parameters, inheritance clauses, where clauses, and member blocks into
+  // the same extension syntax that the public expansion entry points return.
+  let expansionContext = TestMacroExpansionContext()
+  let attribute = AttributeSyntax("@NeedsSendable")
+  let baseElementAttribute = AttributeSyntax("@NeedsBaseElement")
+  let structDecl = try StructDeclSyntax.onlyParsed(from: "public struct Box<T> {}")
+  let baseStructDecl = try StructDeclSyntax.onlyParsed(from: "struct Wrapper<Base> {}")
+  let nonGenericStructDecl = try StructDeclSyntax.onlyParsed(from: "struct Plain {}")
+  let type = IdentifierTypeSyntax.forType(named: "Box")
+  let sequenceType = IdentifierTypeSyntax.forType(named: "WrapperSequence")
+  let conditionalContext = ExtensionMacroContext(
+    macroInvocationNode: attribute,
+    declaration: structDecl,
+    extendedType: type,
+    conformedProtocols: [],
+    expansionContext: expansionContext,
+    diagnosticDomainIdentifier: "ConditionalDomain"
+  )
+  let baseElementContext = ExtensionMacroContext(
+    macroInvocationNode: baseElementAttribute,
+    declaration: baseStructDecl,
+    extendedType: sequenceType,
+    conformedProtocols: [],
+    expansionContext: expansionContext,
+    diagnosticDomainIdentifier: "ConditionalDomain"
+  )
+  let nonGenericContext = ExtensionMacroContext(
+    macroInvocationNode: attribute,
+    declaration: nonGenericStructDecl,
+    extendedType: type,
+    conformedProtocols: [],
+    expansionContext: expansionContext,
+    diagnosticDomainIdentifier: "ConditionalDomain"
+  )
+  let parameters = AllOrNoneConditionalConformanceParameters(
+    genericParameterNames: ["T"],
+    additionalImplicitParameterNames: ["T.Element"],
+    visibilityLevel: .public,
+    typeInlinabilityDisposition: .inlinable,
+    methodInlinabilityDisposition: .usableFromInline
+  )
+  
+  #expect(TestConditionalConformanceMacro.requiredProtocolNames == ["Sendable"])
+  #expect(TestConditionalConformanceMacro.conformedProtocolNames == ["Sendable"])
+  #expect(TestConditionalConformanceMacro.additionalImplicitGenericParameterNames.isEmpty)
+  #expect(parameters.allGenericParameterNames == ["T", "T.Element"])
+  #expect(parameters.description.contains("all-or-none-conformance"))
+  #expect(parameters.debugDescription.contains("AllOrNoneConditionalConformanceParameters"))
+  #expect(Set([parameters, parameters]).count == 1)
+  #expect(try JSONDecoder().decode(
+    AllOrNoneConditionalConformanceParameters.self,
+    from: JSONEncoder().encode(parameters)
+  ) == parameters)
+  #expect(try TestConditionalConformanceMacro.genericParameterNames(in: conditionalContext) == ["T"])
+  #expect(try TestConditionalConformanceMacro.additionalImplicitGenericParameterNames(
+    in: baseElementContext,
+    genericParameterNames: ["Base"]
+  ) == ["Base.Element"])
+  #expect(try TestConditionalConformanceMacro.additionalImplicitGenericParameterNames(
+    in: conditionalContext,
+    genericParameterNames: ["T"]
+  ).isEmpty)
+  expectMacroExpansionFailure {
+    _ = try TestConditionalConformanceMacro.genericParameterNames(
+      in: nonGenericContext
+    )
+  }
+  #expect(try TestConditionalConformanceMacro.conditionalConformanceInheritanceClause(
+    in: conditionalContext,
+    parameters: parameters
+  ).trimmedDescription == ": Sendable")
+  #expect(try TestConditionalConformanceMacro.conditionalConformanceRequirementsClause(
+    in: conditionalContext,
+    parameters: parameters
+  ).trimmedDescription == "where T: Sendable, T.Element: Sendable")
+  #expect(try TestConditionalConformanceMacro.conditionalConformanceDeclarations(
+    in: conditionalContext,
+    parameters: parameters
+  ).isEmpty)
+  
+  let conditionalExtensions = try TestConditionalConformanceMacro.expansion(
+    of: attribute,
+    attachedTo: structDecl,
+    providingExtensionsOf: type,
+    conformingTo: [],
+    in: expansionContext
+  )
+  let unconditionalExtensions = try TestUnconditionalConformanceMacro.expansion(
+    of: attribute,
+    attachedTo: structDecl,
+    providingExtensionsOf: type,
+    conformingTo: [],
+    in: expansionContext
+  )
+  
+  #expect(conditionalExtensions.map(\.trimmedDescription) == [
+    "extension Box: Sendable where T: Sendable {}"
+  ])
+  #expect(TestUnconditionalConformanceMacro.conformedProtocolNames == ["Codable"])
+  #expect(try TestUnconditionalConformanceMacro.unconditionalInheritanceClause(in: conditionalContext).trimmedDescription == ": Codable")
+  #expect(try TestUnconditionalConformanceMacro.conditionalConformanceDeclarations(in: conditionalContext).isEmpty)
+  #expect(unconditionalExtensions.map(\.trimmedDescription) == [
+    "extension Box: Codable {}"
+  ])
+  
+  expectMacroExpansionFailure {
+    _ = try TestConditionalConformanceMacro.conditionalConformanceRequirementsClause(
+      in: conditionalContext,
+      parameters: AllOrNoneConditionalConformanceParameters(
+        genericParameterNames: [],
+        additionalImplicitParameterNames: [],
+        visibilityLevel: .internal
+      )
+    )
+  }
+  expectMacroExpansionFailure {
+    _ = try EmptyRequiredProtocolConditionalConformanceMacro.conditionalConformanceRequirementsClause(
+      in: conditionalContext,
+      parameters: AllOrNoneConditionalConformanceParameters(
+        genericParameterNames: ["T"],
+        additionalImplicitParameterNames: [],
+        visibilityLevel: .internal
+      )
+    )
+  }
+}
+
+private struct RequirementMacroContext: MacroContextProtocol {
+  var macroInvocationNode: AttributeSyntax
+  var expansionContext: TestMacroExpansionContext
+  var optionalSelfValue: Int?
+  var selfSyntax: ExprSyntax
+  var optionalSelfSyntax: ExprSyntax?
+  var diagnosticDomainIdentifier: String = "RequirementDomain"
+  
+  init(
+    macroInvocationNode: AttributeSyntax,
+    expansionContext: TestMacroExpansionContext,
+    optionalSelfValue: Int? = nil,
+    selfSyntax: ExprSyntax = ExprSyntax(IntegerLiteralExprSyntax(literal: .integerLiteral("0"))),
+    optionalSelfSyntax: ExprSyntax? = nil
+  ) {
+    self.macroInvocationNode = macroInvocationNode
+    self.expansionContext = expansionContext
+    self.optionalSelfValue = optionalSelfValue
+    self.selfSyntax = selfSyntax
+    self.optionalSelfSyntax = optionalSelfSyntax
+  }
+  
+  var invocationArgumentsAsLabeledExpressionList: LabeledExprListSyntax? {
+    nil
+  }
+}
+
+private struct RequirementSource: CustomStringConvertible {
+  var optionalInt: Int?
+  var optionalValues: [String]?
+  var values: [String]
+  var optionalSyntax: ExprSyntax?
+  var syntax: ExprSyntax
+  var optionalAny: Any?
+  
+  var description: String {
+    "RequirementSource"
+  }
+}
+
+private final class TestMacroExpansionContext: MacroExpansionContext {
+  var diagnostics: [Diagnostic] = []
+  var locationRequests: [(position: PositionInSyntaxNode, filePathMode: SourceLocationFilePathMode)] = []
+  var lexicalContext: [Syntax] = []
+  
+  func makeUniqueName(_ name: String) -> TokenSyntax {
+    .identifier("__\(name)")
+  }
+  
+  func diagnose(_ diagnostic: Diagnostic) {
+    diagnostics.append(diagnostic)
+  }
+  
+  func location(
+    of node: some SyntaxProtocol,
+    at position: PositionInSyntaxNode,
+    filePathMode: SourceLocationFilePathMode
+  ) -> AbstractSourceLocation? {
+    locationRequests.append((position, filePathMode))
+    
+    return AbstractSourceLocation(
+      SourceLocation(
+        line: locationRequests.count,
+        column: 1,
+        offset: locationRequests.count,
+        file: "MacroProtocolSupportTests.swift"
+      )
+    )
+  }
+}
+
+private struct ExampleMacroError: Error {
+  var label: String
+}
+
+private struct UnsupportedDeclSyntax: DeclSyntaxProtocol {
+  let _syntaxNode: Syntax
+  
+  init?(_ node: __shared some SyntaxProtocol) {
+    _syntaxNode = Syntax(node)
+  }
+  
+  static var structure: SyntaxNodeStructure {
+    .layout([])
+  }
+}
+
+private func expectMacroExpansionFailure(
+  _ operation: () throws -> Void,
+  sourceLocation: Testing.SourceLocation = #_sourceLocation
+) {
+  do {
+    try operation()
+    Issue.record("Expected MacroExpansionFailure", sourceLocation: sourceLocation)
+  } catch is MacroExpansionFailure {
+  } catch {
+    Issue.record("Expected MacroExpansionFailure, got \(error)", sourceLocation: sourceLocation)
+  }
+}
+
+private enum DefaultDiagnosticMacro: DiagnosticDomainAwareMacro {}
+
+private enum DefaultTypeAttachedMacro: ContextualizedTypeAttachedMacro {
+  static func validateMacroInvocationNode(_ attributeSyntax: AttributeSyntax) throws {}
+  static func validateMacroInvocationName(_ macroInvocationName: String) throws {}
+  static func validateAttachedTypeName(_ attachedTypeName: String) throws {}
+  static func validateDeclarationArchetype(for attachmentContext: some AttachedMacroContextProtocol) throws {}
+  static func validateDeclarationDetails(for attachmentContext: some AttachedMacroContextProtocol) throws {}
+}
+
+private enum ProtocolIncompatibleMacro: ProtocolIncompatibleContextualizedTypeAttachedMacro {
+  static func validateMacroInvocationNode(_ attributeSyntax: AttributeSyntax) throws {}
+  static func validateMacroInvocationName(_ macroInvocationName: String) throws {}
+  static func validateAttachedTypeName(_ attachedTypeName: String) throws {}
+  static func validateDeclarationArchetype(for attachmentContext: some AttachedMacroContextProtocol) throws {}
+  static func validateDeclarationDetails(for attachmentContext: some AttachedMacroContextProtocol) throws {}
+}
+
+private enum DefaultAccessorMacro: ContextualizedAccessorMacro {
+  static func contextualizedExpansion(
+    in attachmentContext: some AccessorMacroContextProtocol
+  ) throws -> [AccessorDeclSyntax] {
+    _ = try attachmentContext.requireDeclaration(as: VariableDeclSyntax.self)
+    return [AccessorDeclSyntax("get { value }")]
+  }
+}
+
+private enum DefaultBodyMacro: ContextualizedBodyMacro {
+  static func contextualizedExpansion(
+    in attachmentContext: some BodyMacroContextProtocol
+  ) throws -> [CodeBlockItemSyntax] {
+    _ = attachmentContext.declaration.body
+    return [CodeBlockItemSyntax("return 1")]
+  }
+}
+
+private enum DefaultMemberMacro: ContextualizedMemberMacro {
+  static func contextualizedExpansion(
+    in attachmentContext: some MemberMacroContextProtocol
+  ) throws -> [DeclSyntax] {
+    _ = attachmentContext.conformedProtocols
+    return [DeclSyntax(try VariableDeclSyntax("var generatedMember: Int"))]
+  }
+}
+
+private enum DefaultMemberAttributeMacro: ContextualizedMemberAttributeMacro {
+  static func contextualizedExpansion(
+    in attachmentContext: some MemberAttributeMacroContextProtocol
+  ) throws -> [AttributeSyntax] {
+    _ = try attachmentContext.requireMemberAsConcreteDeclSyntax()
+    return [AttributeSyntax("@usableFromInline")]
+  }
+}
+
+private enum DefaultPeerMacro: ContextualizedPeerMacro {
+  static func contextualizedExpansion(
+    in attachmentContext: some PeerMacroContextProtocol
+  ) throws -> [DeclSyntax] {
+    _ = attachmentContext.declaration
+    return [DeclSyntax(try TypeAliasDeclSyntax("typealias GeneratedPeer = Int"))]
+  }
+}
+
+private enum RegexPeerMacro: ContextualizedPeerMacro {
+  static var macroInvocationNameRegex: Regex<Substring>? { /^Allowed$/ }
+  static var attachedTypeNameRegex: Regex<Substring>? { /^Box$/ }
+  
+  static func contextualizedExpansion(
+    in attachmentContext: some PeerMacroContextProtocol
+  ) throws -> [DeclSyntax] {
+    []
+  }
+}
+
+private enum DefaultMarkerMacro: MarkerMacroProtocol {}
+
+private enum DefaultExpressionMacro: ContextualizedExpressionMacro {
+  static func contextualizedExpansion(
+    in attachmentContext: some ExpressionMacroContextProtocol
+  ) throws -> ExprSyntax {
+    #expect(attachmentContext.invocationArgumentsAsLabeledExpressionList?.count == 2)
+    return ExprSyntax(IntegerLiteralExprSyntax(literal: .integerLiteral("42")))
+  }
+}
+
+private enum DefaultDeclarationMacro: ContextualizedDeclarationMacro {
+  static func validateFreestandingContext(
+    _ expansionContext: some DeclarationMacroContextProtocol
+  ) throws {
+    #expect(expansionContext.invocationArgumentsAsLabeledExpressionList?.count == 1)
+  }
+  
+  static func contextualizedExpansion(
+    in attachmentContext: some DeclarationMacroContextProtocol
+  ) throws -> [DeclSyntax] {
+    [DeclSyntax(try StructDeclSyntax("struct GeneratedDeclaration {}"))]
+  }
+}
+
+private enum TestConditionalConformanceMacro: SingleProtocolConditionalConformanceMacro {
+  static let associatedProtocol = "Sendable"
+}
+
+private enum EmptyRequiredProtocolConditionalConformanceMacro: AllOrNoneConditionalConformanceMacro {
+  static let requiredProtocolNames: [String] = []
+  static let conformedProtocolNames = ["MarkerProtocol"]
+}
+
+private enum TestUnconditionalConformanceMacro: SingleProtocolUnconditionalConformanceMacro {
+  static let associatedProtocol = "Codable"
+}

--- a/Tests/MacroToolboxTests/Model/ArgumentAndPerformanceModel+Tests.swift
+++ b/Tests/MacroToolboxTests/Model/ArgumentAndPerformanceModel+Tests.swift
@@ -1,0 +1,422 @@
+import SwiftSyntax
+import Testing
+@testable import MacroToolbox
+
+@Test("Argument label descriptors parse and render declaration labels")
+func testArgumentLabelDescriptorsParseAndRenderDeclarationLabels() throws {
+  // Hand-written examples: `_` represents an unlabeled argument, identifier text
+  // represents a labeled argument, and empty or non-word strings are rejected.
+  let unlabeled = try #require(ArgumentLabelDescriptor(declarationSourceCodeRepresentation: "_"))
+  let labeled = try #require(ArgumentLabelDescriptor(declarationSourceCodeRepresentation: "value"))
+  
+  #expect(unlabeled == .unlabeled)
+  #expect(unlabeled.id == unlabeled)
+  #expect(unlabeled.description == ".unlabeled")
+  #expect(unlabeled.debugDescription == "ArgumentLabelDescriptor.unlabeled")
+  #expect(unlabeled.declarationSourceCodeRepresentation == "_")
+  #expect(unlabeled.invocationSourceCodeRepresentation(forArgumentValue: "input") == "input")
+  
+  #expect(labeled == .labeled("value"))
+  #expect(labeled.id == labeled)
+  #expect(labeled.description == ".label(\"value\")")
+  #expect(labeled.debugDescription == "ArgumentLabelDescriptor.label(\"value\")")
+  #expect(labeled.declarationSourceCodeRepresentation == "value")
+  #expect(labeled.invocationSourceCodeRepresentation(forArgumentValue: "input") == "value: input")
+  
+  #expect(ArgumentLabelDescriptor(declarationSourceCodeRepresentation: "") == nil)
+  #expect(ArgumentLabelDescriptor(declarationSourceCodeRepresentation: "value-name") == nil)
+}
+
+@Test("Argument label descriptors round-trip source representations")
+func testArgumentLabelDescriptorsRoundTripSourceRepresentations() throws {
+  // Property-style test: every accepted declaration representation should
+  // round-trip through the descriptor and render an invocation according to
+  // whether the argument is labeled or unlabeled.
+  let samples: [(source: String, expectedInvocation: String)] = [
+    ("_", "payload"),
+    ("value", "value: payload"),
+    ("value_2", "value_2: payload")
+  ]
+  
+  for sample in samples {
+    let descriptor = try #require(
+      ArgumentLabelDescriptor(declarationSourceCodeRepresentation: sample.source)
+    )
+    
+    #expect(descriptor.declarationSourceCodeRepresentation == sample.source)
+    #expect(descriptor.invocationSourceCodeRepresentation(forArgumentValue: "payload") == sample.expectedInvocation)
+  }
+}
+
+@Test("Argument position descriptors classify call argument positions")
+func testArgumentPositionDescriptorsClassifyCallArgumentPositions() throws {
+  // Hand-written examples: position descriptors should recognize the solitary,
+  // first, last, absolute, and offset-from-last positions in parsed call
+  // arguments.
+  let solitary = try #require(Array(callArguments("call(value)").positionedLabeledExpressions).first)
+  let positioned = Array(try callArguments("call(first, label: second, third)").positionedLabeledExpressions)
+  
+  #expect(solitary.isCompatible(with: .solitary))
+  #expect(solitary.isCompatible(with: ArgumentPositionDescriptor.first))
+  #expect(solitary.isCompatible(with: ArgumentPositionDescriptor.last))
+  #expect(positioned[0].isCompatible(with: ArgumentPositionDescriptor.first))
+  #expect(positioned[1].isCompatible(with: .relativeToFirst(1)))
+  #expect(positioned[1].isCompatible(with: .relativeToLast(1)))
+  #expect(positioned[2].isCompatible(with: ArgumentPositionDescriptor.last))
+  #expect(!positioned[0].isCompatible(with: .solitary))
+  #expect(!positioned[0].isCompatible(with: .relativeToFirst(3)))
+  
+  #expect(ArgumentPositionDescriptor.solitary.description == ".solitary")
+  #expect(ArgumentPositionDescriptor.first.description == ".relativeToFirst(0)")
+  #expect(ArgumentPositionDescriptor.last.description == ".relativeToLast(0)")
+  #expect(ArgumentPositionDescriptor.solitary.debugDescription == "ArgumentPositionDescriptor.solitary")
+  #expect(ArgumentPositionDescriptor.last.debugDescription == "ArgumentPositionDescriptor.relativeToLast(0)")
+  #expect(ArgumentPositionDescriptor.first.id == .first)
+}
+
+@Test("Argument position helpers agree with indexed call arguments")
+func testArgumentPositionHelpersAgreeWithIndexedCallArguments() throws {
+  // Property-style test: the list-level position helpers should return the same
+  // elements and counts as direct index arithmetic over positioned arguments.
+  let arguments = try callArguments("call(first, label: second, third)")
+  let positioned = Array(arguments.positionedLabeledExpressions)
+  let descriptors: [ArgumentPositionDescriptor] = [
+    .solitary,
+    .first,
+    .relativeToFirst(1),
+    .relativeToLast(1),
+    .last,
+    .relativeToFirst(5)
+  ]
+  
+  for descriptor in descriptors {
+    let matching = positioned.filter { $0.isCompatible(with: descriptor) }
+    
+    #expect(arguments.firstElement(compatibleWith: descriptor) == matching.first?.labeledExpression)
+    #expect(arguments.countOfElements(compatibleWith: descriptor) == matching.count)
+  }
+}
+
+@Test("Argument location descriptors combine labels and positions")
+func testArgumentLocationDescriptorsCombineLabelsAndPositions() throws {
+  // Hand-written examples: location descriptors should match by position, by
+  // label, or by both dimensions when they are combined.
+  let positioned = Array(try callArguments("call(first, label: second, third)").positionedLabeledExpressions)
+  let first = ArgumentLocationDescriptor.first
+  let labelOnly = ArgumentLocationDescriptor.labeled("label")
+  let absoluteAndLabel = ArgumentLocationDescriptor.absolute(position: 1).with(label: "label")
+  let lastUnlabeled = ArgumentLocationDescriptor.last.unlabeled()
+  
+  #expect(positioned[0].isCompatible(with: first))
+  #expect(positioned[1].isCompatible(with: labelOnly))
+  #expect(positioned[1].isCompatible(with: absoluteAndLabel))
+  #expect(positioned[2].isCompatible(with: lastUnlabeled))
+  #expect(!positioned[0].isCompatible(with: absoluteAndLabel))
+  #expect(!positioned[1].isCompatible(with: lastUnlabeled))
+  
+  #expect(first.storage.positionDescriptor == .first)
+  #expect(first.storage.labelDescriptor == nil)
+  #expect(labelOnly.storage.positionDescriptor == nil)
+  #expect(labelOnly.storage.labelDescriptor == .labeled("label"))
+  #expect(absoluteAndLabel.storage.positionDescriptor == .relativeToFirst(1))
+  #expect(absoluteAndLabel.storage.labelDescriptor == .labeled("label"))
+  #expect(first.storage.description == ".position(.relativeToFirst(0))")
+  #expect(first.storage.debugDescription == "ArgumentLocationDescriptorStorage.position(ArgumentPositionDescriptor.relativeToFirst(0))")
+  #expect(labelOnly.storage.description == ".label(.label(\"label\"))")
+  #expect(labelOnly.storage.debugDescription == "ArgumentLocationDescriptorStorage.label(ArgumentLabelDescriptor.label(\"label\"))")
+  #expect(labelOnly.storage.with(label: "other") == .label(.labeled("other")))
+  #expect(first.storage.with(position: .last) == .position(.last))
+  #expect(String(describing: absoluteAndLabel).contains(".positionAndLabel"))
+  #expect(String(reflecting: absoluteAndLabel).contains("ArgumentLocationDescriptor"))
+}
+
+@Test("Argument location descriptors match equivalent storage composition")
+func testArgumentLocationDescriptorsMatchEquivalentStorageComposition() throws {
+  // Property-style test: composing labels and positions in either order should
+  // produce the same storage, and direct storage compatibility should match the
+  // public descriptor compatibility wrapper.
+  let positioned = Array(try callArguments("call(first, label: second, third)").positionedLabeledExpressions)
+  let equivalentPairs = [
+    (
+      ArgumentLocationDescriptor.first.with(label: "label"),
+      ArgumentLocationDescriptor.labeled("label").with(absolutePosition: 0)
+    ),
+    (
+      ArgumentLocationDescriptor.offsetFromLast(by: 1).with(label: "label"),
+      ArgumentLocationDescriptor.labeled("label").with(offsetFromLast: 1)
+    )
+  ]
+  
+  for (lhs, rhs) in equivalentPairs {
+    #expect(lhs.storage == rhs.storage)
+  }
+  
+  for argument in positioned {
+    let descriptors = [
+      ArgumentLocationDescriptor.first,
+      ArgumentLocationDescriptor.last,
+      ArgumentLocationDescriptor.labeled("label"),
+      ArgumentLocationDescriptor.absolute(position: argument.positionIndex),
+      ArgumentLocationDescriptor.offsetFromLast(by: argument.peerCount - argument.positionIndex - 1)
+    ]
+    
+    for descriptor in descriptors {
+      #expect(argument.isCompatible(with: descriptor) == argument.isCompatible(with: descriptor.storage))
+    }
+  }
+}
+
+@Test("Label criteria classify labeled expressions")
+func testLabelCriteriaClassifyLabeledExpressions() throws {
+  // Hand-written examples: label criteria should accept any label when
+  // unspecified, require nil labels for `.mustBeNil`, and require an exact token
+  // match for `.exactly`.
+  let arguments = Array(try callArguments("call(first, label: second)").positionedLabeledExpressions)
+  let unlabeled = arguments[0].labeledExpression
+  let labeled = arguments[1].labeledExpression
+  
+  #expect(unlabeled.satisfies(labelCriterion: .unspecified))
+  #expect(unlabeled.satisfies(labelCriterion: .mustBeNil))
+  #expect(!unlabeled.satisfies(labelCriterion: .exactly("label")))
+  #expect(labeled.satisfies(labelCriterion: .unspecified))
+  #expect(!labeled.satisfies(labelCriterion: .mustBeNil))
+  #expect(labeled.satisfies(labelCriterion: .exactly("label")))
+  #expect(!labeled.satisfies(labelCriterion: .exactly("other")))
+  
+  #expect(LabelCriterion.unspecified.description == ".unspecified")
+  #expect(LabelCriterion.mustBeNil.description == ".mustBeNil")
+  #expect(LabelCriterion.unspecified.debugDescription == "LabelCriterion.unspecified")
+  #expect(LabelCriterion.mustBeNil.debugDescription == "LabelCriterion.mustBeNil")
+  #expect(LabelCriterion.exactly("label").description == ".exactly(\"label\")")
+  #expect(LabelCriterion.exactly("label").debugDescription == "LabelCriterion.exactly(\"label\")")
+}
+
+@Test("Label criteria lists agree with element-wise satisfaction")
+func testLabelCriteriaListsAgreeWithElementWiseSatisfaction() throws {
+  // Property-style test: list-level label matching should be true exactly when
+  // the criteria count matches the argument count and every paired element
+  // satisfies its criterion.
+  let arguments = try callArguments("call(first, label: second, other: third)")
+  let criteriaSets: [[LabelCriterion]] = [
+    [.mustBeNil, .exactly("label"), .exactly("other")],
+    [.unspecified, .unspecified, .unspecified],
+    [.mustBeNil, .exactly("other"), .exactly("label")],
+    [.mustBeNil]
+  ]
+  
+  for criteria in criteriaSets {
+    let expected = criteria.count == arguments.count
+    &&
+    zip(arguments, criteria).allSatisfy { expression, criterion in
+      expression.satisfies(labelCriterion: criterion)
+    }
+    
+    #expect(arguments.satisfies(labelCriteria: criteria) == expected)
+  }
+}
+
+@Test("Performance annotation disposition renders strongest valid annotations")
+func testPerformanceAnnotationDispositionRendersStrongestValidAnnotations() {
+  // Hand-written examples: the combined disposition should upgrade type and
+  // stored-property inlinability to `@usableFromInline`, retain `@inlinable` for
+  // functions, and omit explicit inline attributes where Swift does not allow
+  // them.
+  let fullHint = PerformanceAnnotationDisposition(
+    inlinabilityDisposition: .inlinable,
+    explicitInlineDisposition: .always
+  )
+  let noHint = PerformanceAnnotationDisposition(
+    inlinabilityDisposition: nil,
+    explicitInlineDisposition: nil
+  )
+  
+  #expect(
+    fullHint.performanceAnnotationSourceCodeRepresentation(
+      visibilityLevel: .internal,
+      attachmentSite: .functionOrMethodDeclaration
+    )
+    ==
+    "@inlinable @inline(__always)\n"
+  )
+  #expect(
+    fullHint.performanceAnnotationSourceCodeRepresentation(
+      visibilityLevel: .internal,
+      attachmentSite: .typeDeclaration,
+      includeTrailingNewlineWhenNecessary: false
+    )
+    ==
+    "@usableFromInline"
+  )
+  #expect(
+    fullHint.performanceAnnotationSourceCodeRepresentation(
+      visibilityLevel: .internal,
+      attachmentSite: .storedPropertyDeclaration,
+      separatorBetweenAnnotations: " | "
+    )
+    ==
+    "@usableFromInline\n"
+  )
+  #expect(
+    noHint.performanceAnnotationSourceCodeRepresentation(
+      visibilityLevel: .private,
+      attachmentSite: .functionOrMethodDeclaration
+    )
+    ==
+    nil
+  )
+  #expect(PerformanceAnnotationDisposition.allCases.count == 9)
+}
+
+@Test("Performance annotation policy matches visibility and attachment matrices")
+func testPerformanceAnnotationPolicyMatchesVisibilityAndAttachmentMatrices() {
+  // Property-style test: across all visibility levels, attachment sites, and
+  // hint combinations, the rendered annotation should equal the independently
+  // tabulated strongest inlinability plus any attachment-appropriate explicit
+  // inline disposition.
+  for disposition in PerformanceAnnotationDisposition.allCases {
+    for visibility in VisibilityLevel.allCases {
+      for site in PerformanceAnnotationAttachmentSite.allCases {
+        let expectedChunks = [
+          expectedStrongestInlinability(
+            site: site,
+            visibility: visibility,
+            hint: disposition.inlinabilityDisposition
+          )?.sourceCodeStringRepresentation,
+          disposition.explicitInlineDisposition
+            .flatMap { expectedExplicitInline(site: site, disposition: $0) }?
+            .sourceCodeStringRepresentation
+        ].compactMap { $0 }
+        let expected = expectedChunks.unlessEmpty?.joined(separator: " | ")
+        
+        #expect(
+          disposition.performanceAnnotationSourceCodeRepresentation(
+            visibilityLevel: visibility,
+            attachmentSite: site,
+            includeTrailingNewlineWhenNecessary: false,
+            separatorBetweenAnnotations: " | "
+          )
+          ==
+          expected
+        )
+        #expect(
+          InlinabilityDisposition.strongestAvailableDisposition(
+            attachmentSite: site,
+            declarationVisibility: visibility,
+            dispositionHint: disposition.inlinabilityDisposition
+          )
+          ==
+          expectedStrongestInlinability(
+            site: site,
+            visibility: visibility,
+            hint: disposition.inlinabilityDisposition
+          )
+        )
+      }
+    }
+  }
+}
+
+@Test("Inline and transparent disposition helpers expose case semantics")
+func testInlineAndTransparentDispositionHelpersExposeCaseSemantics() throws {
+  // Hand-written examples: explicit inline dispositions render their source
+  // attributes, are valid only for function/method sites, and transparent
+  // disposition derives its name from its single case.
+  #expect(ExplicitInlineDisposition.always.sourceCodeStringRepresentation == "@inline(__always)")
+  #expect(ExplicitInlineDisposition.never.sourceCodeStringRepresentation == "@inline(never)")
+  #expect(ExplicitInlineDisposition.always.appropriateDisposition(forAttachmentSite: .functionOrMethodDeclaration) == .always)
+  #expect(ExplicitInlineDisposition.always.appropriateDisposition(forAttachmentSite: .typeDeclaration) == nil)
+  #expect(ExplicitInlineDisposition.never.appropriateDisposition(forAttachmentSite: .storedPropertyDeclaration) == nil)
+  #expect(ExplicitInlineDisposition(attributeArgument: "__always") == .always)
+  #expect(ExplicitInlineDisposition(attributeArgument: "never") == .never)
+  #expect(ExplicitInlineDisposition(attributeArgument: "sometimes") == nil)
+  #expect(ExplicitInlineDisposition(attributeSyntax: AttributeSyntax("@inline(__always)")) == .always)
+  #expect(ExplicitInlineDisposition(attributeSyntax: AttributeSyntax("@inline(never)")) == .never)
+  #expect(ExplicitInlineDisposition(attributeSyntax: AttributeSyntax("@discardableResult")) == nil)
+  #expect(InlinabilityDisposition(tokenSyntax: .identifier("discardableResult")) == nil)
+  #expect(InlinabilityDisposition(attributeSyntax: AttributeSyntax("@inlinable(always)")) == nil)
+  #expect(
+    InlinabilityDisposition(
+      attributeListElement: .ifConfigDecl(
+        IfConfigDeclSyntax(
+          clauses: IfConfigClauseListSyntax([])
+        )
+      )
+    )
+    ==
+    nil
+  )
+  #expect(InlinabilityDisposition.inlinable.attributeSyntax.description == "@inlinable")
+  #expect(InlinabilityDisposition.usableFromInline.attributeSyntax.description == "@usableFromInline")
+  #expect(TransparentDisposition.transparent.caseNameWithoutLeadingDot == "transparent")
+  #expect(TransparentDisposition.transparent.description == ".transparent")
+  #expect(TransparentDisposition.transparent.debugDescription == "TransparentDisposition.Type.transparent")
+}
+
+@Test("Inline disposition helpers match case-derived source attributes")
+func testInlineDispositionHelpersMatchCaseDerivedSourceAttributes() throws {
+  // Property-style test: every explicit inline disposition should parse back
+  // from its rendered attribute and should be returned unchanged only for the
+  // function-or-method attachment site.
+  for disposition in ExplicitInlineDisposition.allCases {
+    #expect(ExplicitInlineDisposition(attributeSyntax: AttributeSyntax(stringLiteral: disposition.sourceCodeStringRepresentation)) == disposition)
+    
+    for site in PerformanceAnnotationAttachmentSite.allCases {
+      let expected: ExplicitInlineDisposition? = site == .functionOrMethodDeclaration ? disposition : nil
+      #expect(disposition.appropriateDisposition(forAttachmentSite: site) == expected)
+    }
+  }
+  
+  for disposition in InlinabilityDisposition.allCases {
+    let identifier = try #require(
+      disposition.attributeSyntax.attributeName.as(IdentifierTypeSyntax.self)
+    )
+    
+    #expect(InlinabilityDisposition(attributeSyntax: disposition.attributeSyntax) == disposition)
+    #expect(InlinabilityDisposition(tokenSyntax: identifier.name) == disposition)
+  }
+}
+
+private func callArguments(
+  _ expression: String
+) throws -> LabeledExprListSyntax {
+  try FunctionCallExprSyntax
+    .firstParsed(from: "let value = \(expression)")
+    .arguments
+}
+
+private func expectedStrongestInlinability(
+  site: PerformanceAnnotationAttachmentSite,
+  visibility: VisibilityLevel,
+  hint: InlinabilityDisposition?
+) -> InlinabilityDisposition? {
+  switch site {
+  case .functionOrMethodDeclaration:
+    switch visibility {
+    case .private, .fileprivate, .open:
+      nil
+    case .internal, .package:
+      hint == nil ? nil : .inlinable
+    case .public:
+      .inlinable
+    }
+  case .typeDeclaration, .storedPropertyDeclaration:
+    switch visibility {
+    case .internal where hint != nil, .package where hint != nil:
+      .usableFromInline
+    default:
+      nil
+    }
+  }
+}
+
+private func expectedExplicitInline(
+  site: PerformanceAnnotationAttachmentSite,
+  disposition: ExplicitInlineDisposition
+) -> ExplicitInlineDisposition? {
+  switch site {
+  case .functionOrMethodDeclaration:
+    disposition
+  case .typeDeclaration, .storedPropertyDeclaration:
+    nil
+  }
+}

--- a/Tests/MacroToolboxTests/Model/ConcreteDeclarationModel+Tests.swift
+++ b/Tests/MacroToolboxTests/Model/ConcreteDeclarationModel+Tests.swift
@@ -1,0 +1,703 @@
+import SwiftSyntax
+import Testing
+@testable import MacroToolbox
+
+@Test("Concrete declaration wrappers preserve SwiftSyntax declaration cases")
+func testConcreteDeclarationWrappersPreserveSwiftSyntaxDeclarationCases() throws {
+  // Hand-written examples: every SwiftSyntax declaration kind supported by
+  // ConcreteDeclSyntax should initialize into the matching enum case, including
+  // declarations that need to be constructed manually rather than parsed.
+  let fixtures = try concreteDeclarationFixtures()
+  
+  for fixture in fixtures {
+    let concrete = try #require(concreteDeclSyntax(from: fixture.declaration))
+    
+    #expect(concrete.caseName == fixture.expectedCaseName)
+    #expect(concrete.isConcreteTypeDeclaration == (fixture.expectedTypeDeclarationArchetype != nil))
+    #expect(concrete.concreteTypeDeclaration?.caseName == fixture.expectedTypeDeclarationArchetype)
+  }
+  
+  let accessor = try #require(fixtures.first { $0.expectedCaseName == "accessor" })
+  let concreteAccessor = try #require(concreteDeclSyntax(from: accessor.declaration))
+  #expect(concreteAccessor.modifiers == nil)
+  #expect(concreteAccessor.attributes?.isEmpty == true)
+}
+
+@Test("Concrete declaration wrapper forwarding matches wrapped syntax")
+func testConcreteDeclarationWrapperForwardingMatchesWrappedSyntax() throws {
+  // Property-style test: for all supported concrete declaration cases, forwarded
+  // modifiers, visibility, attributes, and type-declaration projection should
+  // agree with the same information read directly from the wrapped syntax.
+  let fixtures = try concreteDeclarationFixtures()
+  
+  for fixture in fixtures {
+    let concrete = try #require(concreteDeclSyntax(from: fixture.declaration))
+    
+    #expect(concrete.modifiers?.map(\.name.text) == fixture.expectedModifierNames)
+    #expect(concrete.visibilityLevel == fixture.expectedVisibilityLevel)
+    #expect(concrete.attributes?.count == fixture.expectedAttributeCount)
+    #expect(concrete.concreteTypeDeclaration?.name == fixture.expectedTypeName)
+  }
+}
+
+@Test("Concrete type declaration wrappers expose shared type metadata")
+func testConcreteTypeDeclarationWrappersExposeSharedTypeMetadata() throws {
+  // Hand-written examples: actor, class, enum, and struct wrappers should expose
+  // the wrapped declaration's name, modifiers, inheritance, generics, where
+  // clause, attributes, visibility, and corresponding ConcreteDeclSyntax case.
+  let sourceFile = try SourceFileSyntax.onlyParsed(
+    from: """
+    @usableFromInline
+    internal actor Worker<State>: Sendable where State: Sendable {}
+    public class Box<Element>: NSObject {}
+    enum Choice<Value>: Sendable where Value: Sendable { case value(Value) }
+    private struct Pair<First, Second>: Sendable {}
+    """
+  )
+  let actor = try #require(sourceFile.firstSyntaxElement(ofType: ActorDeclSyntax.self))
+  let classDecl = try #require(sourceFile.firstSyntaxElement(ofType: ClassDeclSyntax.self))
+  let enumDecl = try #require(sourceFile.firstSyntaxElement(ofType: EnumDeclSyntax.self))
+  let structDecl = try #require(sourceFile.firstSyntaxElement(ofType: StructDeclSyntax.self))
+  
+  let declarations = [
+    try #require(ConcreteTypeDeclaration(decl: actor)),
+    try #require(ConcreteTypeDeclaration(decl: classDecl)),
+    try #require(ConcreteTypeDeclaration(decl: enumDecl)),
+    try #require(ConcreteTypeDeclaration(decl: structDecl))
+  ]
+  
+  #expect(declarations.map(\.name) == ["Worker", "Box", "Choice", "Pair"])
+  #expect(declarations.map(\.explicitVisibilityLevel) == [.internal, .public, nil, .private])
+  #expect(declarations.map(\.inlinabilityDisposition) == [.usableFromInline, nil, nil, nil])
+  #expect(declarations.map { $0.genericParameterClause != nil } == [true, true, true, true])
+  #expect(declarations.map { $0.inheritanceClause != nil } == [true, true, true, true])
+  #expect(declarations.map { $0.genericWhereClause != nil } == [true, false, true, false])
+  #expect(declarations.map(\.concreteDeclSyntax.caseName) == ["actor", "class", "enum", "struct"])
+  #expect(ConcreteTypeDeclaration(decl: try VariableDeclSyntax.onlyParsed(from: "let value = 1")) == nil)
+}
+
+@Test("Concrete type declaration wrappers match direct SwiftSyntax access")
+func testConcreteTypeDeclarationWrappersMatchDirectSwiftSyntaxAccess() throws {
+  // Property-style test: the type wrapper is a lossless projection over the
+  // supported declaration nodes, so each property should match a direct switch
+  // over the concrete SwiftSyntax declaration.
+  let sourceFile = try SourceFileSyntax.onlyParsed(
+    from: """
+    actor Worker<State>: Sendable where State: Sendable {}
+    class Box<Element>: NSObject {}
+    enum Choice<Value>: Sendable where Value: Sendable { case value(Value) }
+    struct Pair<First, Second>: Sendable {}
+    """
+  )
+  let actor = try #require(sourceFile.firstSyntaxElement(ofType: ActorDeclSyntax.self))
+  let classDecl = try #require(sourceFile.firstSyntaxElement(ofType: ClassDeclSyntax.self))
+  let enumDecl = try #require(sourceFile.firstSyntaxElement(ofType: EnumDeclSyntax.self))
+  let structDecl = try #require(sourceFile.firstSyntaxElement(ofType: StructDeclSyntax.self))
+  let declarations = [
+    try #require(ConcreteTypeDeclaration(decl: actor)),
+    try #require(ConcreteTypeDeclaration(decl: classDecl)),
+    try #require(ConcreteTypeDeclaration(decl: enumDecl)),
+    try #require(ConcreteTypeDeclaration(decl: structDecl))
+  ]
+  
+  for declaration in declarations {
+    #expect(declaration.name == declaration.nameSyntax.text)
+    #expect(declaration.explicitVisibilityLevel == declaration.modifiers.visibilityLevel)
+    #expect(declaration.inlinabilityDisposition == declaration.attributes.inlinabilityDisposition)
+    #expect(declaration.concreteDeclSyntax.concreteTypeDeclaration == declaration)
+  }
+}
+
+@Test("Concrete data type declaration wrappers expose stored-property metadata")
+func testConcreteDataTypeDeclarationWrappersExposeStoredPropertyMetadata() throws {
+  // Hand-written examples: data-type wrappers should accept only actor, class,
+  // and struct declarations, and should expose names, generics, inheritance,
+  // attributes, visibility, where clauses, and stored-property descriptors.
+  let sourceFile = try SourceFileSyntax.onlyParsed(
+    from: """
+    @usableFromInline
+    internal actor Worker<State>: Sendable where State: Sendable {
+      var state: State
+    }
+    public class Box<Element>: NSObject {
+      var value: Element
+    }
+    private struct Pair<First, Second>: Sendable {
+      var first: First
+      var computed: Int { get { 1 } }
+    }
+    enum Choice { case value }
+    """
+  )
+  let actor = try #require(sourceFile.firstSyntaxElement(ofType: ActorDeclSyntax.self))
+  let classDecl = try #require(sourceFile.firstSyntaxElement(ofType: ClassDeclSyntax.self))
+  let structDecl = try #require(sourceFile.firstSyntaxElement(ofType: StructDeclSyntax.self))
+  let enumDecl = try #require(sourceFile.firstSyntaxElement(ofType: EnumDeclSyntax.self))
+  
+  let declarations = [
+    try #require(ConcreteDataTypeDeclaration(decl: actor)),
+    try #require(ConcreteDataTypeDeclaration(decl: classDecl)),
+    try #require(ConcreteDataTypeDeclaration(decl: structDecl))
+  ]
+  
+  #expect(declarations.map(\.name) == ["Worker", "Box", "Pair"])
+  #expect(declarations.map(\.explicitVisibilityLevel) == [.internal, .public, .private])
+  #expect(declarations.map(\.inlinabilityDisposition) == [.usableFromInline, nil, nil])
+  #expect(declarations.map(\.concreteDeclSyntax.caseName) == ["actor", "class", "struct"])
+  #expect(declarations.map { $0.genericParameterClause != nil } == [true, true, true])
+  #expect(declarations.map { $0.inheritanceClause != nil } == [true, true, true])
+  #expect(declarations.map { $0.genericWhereClause != nil } == [true, false, false])
+  #expect(declarations.map { $0.storedPropertyDescriptors.map(\.storage.variableName) } == [["state"], ["value"], ["first"]])
+  #expect(ConcreteDataTypeDeclaration(decl: enumDecl) == nil)
+}
+
+@Test("Concrete data type declaration wrappers match direct SwiftSyntax access")
+func testConcreteDataTypeDeclarationWrappersMatchDirectSwiftSyntaxAccess() throws {
+  // Property-style test: each data-type wrapper should forward exactly to the
+  // corresponding actor/class/struct declaration for shared metadata and stored
+  // properties.
+  let sourceFile = try SourceFileSyntax.onlyParsed(
+    from: """
+    actor Worker<State>: Sendable where State: Sendable { var state: State }
+    class Box<Element>: NSObject { var value: Element }
+    struct Pair<First, Second>: Sendable { var first: First }
+    """
+  )
+  let actor = try #require(sourceFile.firstSyntaxElement(ofType: ActorDeclSyntax.self))
+  let classDecl = try #require(sourceFile.firstSyntaxElement(ofType: ClassDeclSyntax.self))
+  let structDecl = try #require(sourceFile.firstSyntaxElement(ofType: StructDeclSyntax.self))
+  let declarations = [
+    try #require(ConcreteDataTypeDeclaration(decl: actor)),
+    try #require(ConcreteDataTypeDeclaration(decl: classDecl)),
+    try #require(ConcreteDataTypeDeclaration(decl: structDecl))
+  ]
+  
+  for declaration in declarations {
+    let projectedStoredProperties = try #require(
+      declaration
+        .concreteDeclSyntax
+        .concreteTypeDeclaration?
+        .storedPropertyDescriptorsForDataTypes
+    )
+    
+    #expect(declaration.name == declaration.nameSyntax.text)
+    #expect(declaration.explicitVisibilityLevel == declaration.modifiers.visibilityLevel)
+    #expect(declaration.inlinabilityDisposition == declaration.attributes.inlinabilityDisposition)
+    #expect(declaration.storedPropertyDescriptors == projectedStoredProperties)
+  }
+}
+
+@Test("Data type field structure descriptors summarize stored fields")
+func testDataTypeFieldStructureDescriptorsSummarizeStoredFields() throws {
+  // Hand-written examples: a field-structure descriptor should be available for
+  // data types, expose cloned storage-equivalent snapshots, and ignore computed
+  // properties when listing stored fields.
+  let structure = try StructDeclSyntax.onlyParsed(
+    from: """
+    @usableFromInline
+    internal struct Record<Value>: Sendable where Value: Sendable {
+      @usableFromInline
+      internal var first: Value
+      private var second: String
+      var computed: Int { get { 1 } }
+    }
+    """
+  )
+  let enumDecl = try EnumDeclSyntax.onlyParsed(from: "enum Choice { case value }")
+  let descriptor = try #require(DataTypeFieldStructureDescriptor(decl: structure))
+  let otherDescriptor = try #require(
+    DataTypeFieldStructureDescriptor(
+      decl: try StructDeclSyntax.onlyParsed(from: "struct Other { var value: Int }")
+    )
+  )
+  let clone = descriptor.makeClone()
+  let firstProperty = try #require(descriptor.storedPropertyDescriptors.first)
+  let secondProperty = try #require(descriptor.storedPropertyDescriptors.dropFirst().first)
+  let duplicateFirstPropertyStorage = StoredPropertyDescriptor.Storage(
+    variableName: firstProperty.storage.variableName,
+    primaryBinding: firstProperty.storage.primaryBinding,
+    variableDeclaration: firstProperty.storage.variableDeclaration
+  )
+  
+  #expect(descriptor.name == "Record")
+  #expect(descriptor.dataTypeDeclaration.name == "Record")
+  #expect(descriptor.genericParameterClause?.simpleGenericParameterNames == ["Value"])
+  #expect(descriptor.inheritanceClause != nil)
+  #expect(descriptor.genericWhereClause != nil)
+  #expect(descriptor.storedPropertyDescriptors.map(\.storage.variableName) == ["first", "second"])
+  #expect(descriptor.storage.modifierList.visibilityLevel == .internal)
+  #expect(descriptor.storage.attributeList.inlinabilityDisposition == .usableFromInline)
+  #expect(descriptor.storage.nonConfigurationAttributes.count == 1)
+  #expect(descriptor.storage.visibilityLevel == .internal)
+  #expect(descriptor.storage == descriptor.storage)
+  #expect(!(descriptor.storage == otherDescriptor.storage))
+  #expect(firstProperty.storage.modifierList.visibilityLevel == .internal)
+  #expect(firstProperty.storage.attributeList.inlinabilityDisposition == .usableFromInline)
+  #expect(firstProperty.storage.nonConfigurationAttributes.count == 1)
+  #expect(firstProperty.storage.visibilityLevel == .internal)
+  #expect(firstProperty.storage == duplicateFirstPropertyStorage)
+  #expect(!(firstProperty.storage == firstProperty.storage))
+  #expect(!(firstProperty.storage == secondProperty.storage))
+  #expect(firstProperty.hashValue == firstProperty.hashValue)
+  #expect(descriptor.conditionallyMapFields(transformation: \.storage.variableName) { $0.storage.variableName.hasPrefix("s") } == ["second"])
+  #expect(clone == descriptor)
+  #expect(clone.hashValue == descriptor.hashValue)
+  #expect(DataTypeFieldStructureDescriptor(decl: enumDecl) == nil)
+}
+
+@Test("Data type field structure descriptors match data-type declarations")
+func testDataTypeFieldStructureDescriptorsMatchDataTypeDeclarations() throws {
+  // Property-style test: for every supported data-type declaration, the
+  // field-structure descriptor should match the wrapped declaration's name,
+  // generic syntax, inheritance syntax, and stored-property descriptor list.
+  let sourceFile = try SourceFileSyntax.onlyParsed(
+    from: """
+    actor Worker<State>: Sendable where State: Sendable { var state: State }
+    class Box<Element>: NSObject { var value: Element }
+    struct Pair<First, Second>: Sendable { var first: First }
+    enum Choice { case value }
+    """
+  )
+  let actor = try #require(sourceFile.firstSyntaxElement(ofType: ActorDeclSyntax.self))
+  let classDecl = try #require(sourceFile.firstSyntaxElement(ofType: ClassDeclSyntax.self))
+  let structDecl = try #require(sourceFile.firstSyntaxElement(ofType: StructDeclSyntax.self))
+  let pairs = [
+    (
+      try #require(ConcreteDataTypeDeclaration(decl: actor)),
+      try #require(DataTypeFieldStructureDescriptor(decl: actor))
+    ),
+    (
+      try #require(ConcreteDataTypeDeclaration(decl: classDecl)),
+      try #require(DataTypeFieldStructureDescriptor(decl: classDecl))
+    ),
+    (
+      try #require(ConcreteDataTypeDeclaration(decl: structDecl)),
+      try #require(DataTypeFieldStructureDescriptor(decl: structDecl))
+    )
+  ]
+  
+  for (dataType, descriptor) in pairs {
+    #expect(descriptor.dataTypeDeclaration == dataType)
+    #expect(descriptor.name == dataType.name)
+    #expect(descriptor.genericParameterClause == dataType.genericParameterClause)
+    #expect(descriptor.inheritanceClause == dataType.inheritanceClause)
+    #expect(descriptor.genericWhereClause == dataType.genericWhereClause)
+    #expect(descriptor.storedPropertyDescriptors == dataType.storedPropertyDescriptors)
+  }
+  
+  #expect(DataTypeFieldStructureDescriptor(decl: try #require(sourceFile.firstSyntaxElement(ofType: EnumDeclSyntax.self))) == nil)
+}
+
+private struct ConcreteDeclarationFixture {
+  var declaration: any DeclSyntaxProtocol
+  var expectedCaseName: String
+  var expectedTypeDeclarationArchetype: String?
+  var expectedModifierNames: [String]?
+  var expectedVisibilityLevel: VisibilityLevel?
+  var expectedAttributeCount: Int?
+  var expectedTypeName: String?
+}
+
+private func concreteDeclSyntax(
+  from declaration: any DeclSyntaxProtocol
+) -> ConcreteDeclSyntax? {
+  if let declaration = declaration.as(AccessorDeclSyntax.self) {
+    ConcreteDeclSyntax(decl: declaration)
+  } else if let declaration = declaration.as(ActorDeclSyntax.self) {
+    ConcreteDeclSyntax(decl: declaration)
+  } else if let declaration = declaration.as(AssociatedTypeDeclSyntax.self) {
+    ConcreteDeclSyntax(decl: declaration)
+  } else if let declaration = declaration.as(ClassDeclSyntax.self) {
+    ConcreteDeclSyntax(decl: declaration)
+  } else if let declaration = declaration.as(DeinitializerDeclSyntax.self) {
+    ConcreteDeclSyntax(decl: declaration)
+  } else if let declaration = declaration.as(EditorPlaceholderDeclSyntax.self) {
+    ConcreteDeclSyntax(decl: declaration)
+  } else if let declaration = declaration.as(EnumCaseDeclSyntax.self) {
+    ConcreteDeclSyntax(decl: declaration)
+  } else if let declaration = declaration.as(EnumDeclSyntax.self) {
+    ConcreteDeclSyntax(decl: declaration)
+  } else if let declaration = declaration.as(ExtensionDeclSyntax.self) {
+    ConcreteDeclSyntax(decl: declaration)
+  } else if let declaration = declaration.as(FunctionDeclSyntax.self) {
+    ConcreteDeclSyntax(decl: declaration)
+  } else if let declaration = declaration.as(IfConfigDeclSyntax.self) {
+    ConcreteDeclSyntax(decl: declaration)
+  } else if let declaration = declaration.as(ImportDeclSyntax.self) {
+    ConcreteDeclSyntax(decl: declaration)
+  } else if let declaration = declaration.as(InitializerDeclSyntax.self) {
+    ConcreteDeclSyntax(decl: declaration)
+  } else if let declaration = declaration.as(MacroDeclSyntax.self) {
+    ConcreteDeclSyntax(decl: declaration)
+  } else if let declaration = declaration.as(MacroExpansionDeclSyntax.self) {
+    ConcreteDeclSyntax(decl: declaration)
+  } else if let declaration = declaration.as(MissingDeclSyntax.self) {
+    ConcreteDeclSyntax(decl: declaration)
+  } else if let declaration = declaration.as(OperatorDeclSyntax.self) {
+    ConcreteDeclSyntax(decl: declaration)
+  } else if let declaration = declaration.as(PoundSourceLocationSyntax.self) {
+    ConcreteDeclSyntax(decl: declaration)
+  } else if let declaration = declaration.as(PrecedenceGroupDeclSyntax.self) {
+    ConcreteDeclSyntax(decl: declaration)
+  } else if let declaration = declaration.as(ProtocolDeclSyntax.self) {
+    ConcreteDeclSyntax(decl: declaration)
+  } else if let declaration = declaration.as(StructDeclSyntax.self) {
+    ConcreteDeclSyntax(decl: declaration)
+  } else if let declaration = declaration.as(SubscriptDeclSyntax.self) {
+    ConcreteDeclSyntax(decl: declaration)
+  } else if let declaration = declaration.as(TypeAliasDeclSyntax.self) {
+    ConcreteDeclSyntax(decl: declaration)
+  } else if let declaration = declaration.as(VariableDeclSyntax.self) {
+    ConcreteDeclSyntax(decl: declaration)
+  } else {
+    nil
+  }
+}
+
+private func concreteDeclarationFixtures() throws -> [ConcreteDeclarationFixture] {
+  let sourceFile = try SourceFileSyntax.onlyParsed(
+    from: """
+    import Foundation
+    #sourceLocation(file: "Fixture.swift", line: 10)
+    public actor Worker {}
+    final class Box {
+      init() {}
+      deinit {}
+      subscript(index: Int) -> Int { index }
+      var value: Int { get { 0 } }
+      func run() {}
+    }
+    enum Choice { case one }
+    extension Choice {}
+    protocol Service { associatedtype Output }
+    struct Pair {}
+    typealias Alias = Int
+    operator infix +++
+    precedencegroup CustomPrecedence {}
+    macro generated() = #externalMacro(module: "M", type: "T")
+    #if os(macOS)
+    let conditional = true
+    #endif
+    let value = 1
+    """
+  )
+  let macroExpansion = MacroExpansionDeclSyntax(
+    macroName: .identifier("expand"),
+    arguments: []
+  )
+  let editorPlaceholder = EditorPlaceholderDeclSyntax(
+    modifiers: [DeclModifierSyntax(name: .keyword(.public))],
+    placeholder: .identifier("<#code#>")
+  )
+  let missing = MissingDeclSyntax(
+    attributes: [.attribute(AttributeSyntax(attributeName: IdentifierTypeSyntax.forType(named: "MissingAttribute")))],
+    modifiers: [DeclModifierSyntax(name: .keyword(.private))],
+    placeholder: .identifier("<#missing#>")
+  )
+  
+  return [
+    ConcreteDeclarationFixture(
+      declaration: try #require(sourceFile.firstSyntaxElement(ofType: AccessorDeclSyntax.self)),
+      expectedCaseName: "accessor",
+      expectedTypeDeclarationArchetype: nil,
+      expectedModifierNames: nil,
+      expectedVisibilityLevel: nil,
+      expectedAttributeCount: 0,
+      expectedTypeName: nil
+    ),
+    ConcreteDeclarationFixture(
+      declaration: try #require(sourceFile.firstSyntaxElement(ofType: ActorDeclSyntax.self)),
+      expectedCaseName: "actor",
+      expectedTypeDeclarationArchetype: "actor",
+      expectedModifierNames: ["public"],
+      expectedVisibilityLevel: .public,
+      expectedAttributeCount: 0,
+      expectedTypeName: "Worker"
+    ),
+    ConcreteDeclarationFixture(
+      declaration: try #require(sourceFile.firstSyntaxElement(ofType: AssociatedTypeDeclSyntax.self)),
+      expectedCaseName: "associatedtype",
+      expectedTypeDeclarationArchetype: nil,
+      expectedModifierNames: [],
+      expectedVisibilityLevel: nil,
+      expectedAttributeCount: 0,
+      expectedTypeName: nil
+    ),
+    ConcreteDeclarationFixture(
+      declaration: try #require(sourceFile.firstSyntaxElement(ofType: ClassDeclSyntax.self)),
+      expectedCaseName: "class",
+      expectedTypeDeclarationArchetype: "class",
+      expectedModifierNames: ["final"],
+      expectedVisibilityLevel: nil,
+      expectedAttributeCount: 0,
+      expectedTypeName: "Box"
+    ),
+    ConcreteDeclarationFixture(
+      declaration: try #require(sourceFile.firstSyntaxElement(ofType: DeinitializerDeclSyntax.self)),
+      expectedCaseName: "deinitializer",
+      expectedTypeDeclarationArchetype: nil,
+      expectedModifierNames: [],
+      expectedVisibilityLevel: nil,
+      expectedAttributeCount: 0,
+      expectedTypeName: nil
+    ),
+    ConcreteDeclarationFixture(
+      declaration: editorPlaceholder,
+      expectedCaseName: "editorPlaceholder",
+      expectedTypeDeclarationArchetype: nil,
+      expectedModifierNames: ["public"],
+      expectedVisibilityLevel: .public,
+      expectedAttributeCount: 0,
+      expectedTypeName: nil
+    ),
+    ConcreteDeclarationFixture(
+      declaration: try #require(sourceFile.firstSyntaxElement(ofType: EnumCaseDeclSyntax.self)),
+      expectedCaseName: "enumCase",
+      expectedTypeDeclarationArchetype: nil,
+      expectedModifierNames: [],
+      expectedVisibilityLevel: nil,
+      expectedAttributeCount: 0,
+      expectedTypeName: nil
+    ),
+    ConcreteDeclarationFixture(
+      declaration: try #require(sourceFile.firstSyntaxElement(ofType: EnumDeclSyntax.self)),
+      expectedCaseName: "enum",
+      expectedTypeDeclarationArchetype: "enum",
+      expectedModifierNames: [],
+      expectedVisibilityLevel: nil,
+      expectedAttributeCount: 0,
+      expectedTypeName: "Choice"
+    ),
+    ConcreteDeclarationFixture(
+      declaration: try #require(sourceFile.firstSyntaxElement(ofType: ExtensionDeclSyntax.self)),
+      expectedCaseName: "extension",
+      expectedTypeDeclarationArchetype: nil,
+      expectedModifierNames: [],
+      expectedVisibilityLevel: nil,
+      expectedAttributeCount: 0,
+      expectedTypeName: nil
+    ),
+    ConcreteDeclarationFixture(
+      declaration: try #require(sourceFile.firstSyntaxElement(ofType: FunctionDeclSyntax.self)),
+      expectedCaseName: "function",
+      expectedTypeDeclarationArchetype: nil,
+      expectedModifierNames: [],
+      expectedVisibilityLevel: nil,
+      expectedAttributeCount: 0,
+      expectedTypeName: nil
+    ),
+    ConcreteDeclarationFixture(
+      declaration: try #require(sourceFile.firstSyntaxElement(ofType: IfConfigDeclSyntax.self)),
+      expectedCaseName: "ifConfig",
+      expectedTypeDeclarationArchetype: nil,
+      expectedModifierNames: nil,
+      expectedVisibilityLevel: nil,
+      expectedAttributeCount: nil,
+      expectedTypeName: nil
+    ),
+    ConcreteDeclarationFixture(
+      declaration: try #require(sourceFile.firstSyntaxElement(ofType: ImportDeclSyntax.self)),
+      expectedCaseName: "import",
+      expectedTypeDeclarationArchetype: nil,
+      expectedModifierNames: [],
+      expectedVisibilityLevel: nil,
+      expectedAttributeCount: 0,
+      expectedTypeName: nil
+    ),
+    ConcreteDeclarationFixture(
+      declaration: try #require(sourceFile.firstSyntaxElement(ofType: InitializerDeclSyntax.self)),
+      expectedCaseName: "initializer",
+      expectedTypeDeclarationArchetype: nil,
+      expectedModifierNames: [],
+      expectedVisibilityLevel: nil,
+      expectedAttributeCount: 0,
+      expectedTypeName: nil
+    ),
+    ConcreteDeclarationFixture(
+      declaration: try #require(sourceFile.firstSyntaxElement(ofType: MacroDeclSyntax.self)),
+      expectedCaseName: "macro",
+      expectedTypeDeclarationArchetype: nil,
+      expectedModifierNames: [],
+      expectedVisibilityLevel: nil,
+      expectedAttributeCount: 0,
+      expectedTypeName: nil
+    ),
+    ConcreteDeclarationFixture(
+      declaration: macroExpansion,
+      expectedCaseName: "macroExpansion",
+      expectedTypeDeclarationArchetype: nil,
+      expectedModifierNames: [],
+      expectedVisibilityLevel: nil,
+      expectedAttributeCount: 0,
+      expectedTypeName: nil
+    ),
+    ConcreteDeclarationFixture(
+      declaration: missing,
+      expectedCaseName: "missing",
+      expectedTypeDeclarationArchetype: nil,
+      expectedModifierNames: ["private"],
+      expectedVisibilityLevel: .private,
+      expectedAttributeCount: 1,
+      expectedTypeName: nil
+    ),
+    ConcreteDeclarationFixture(
+      declaration: try #require(sourceFile.firstSyntaxElement(ofType: OperatorDeclSyntax.self)),
+      expectedCaseName: "operator",
+      expectedTypeDeclarationArchetype: nil,
+      expectedModifierNames: nil,
+      expectedVisibilityLevel: nil,
+      expectedAttributeCount: nil,
+      expectedTypeName: nil
+    ),
+    ConcreteDeclarationFixture(
+      declaration: try #require(sourceFile.firstSyntaxElement(ofType: PoundSourceLocationSyntax.self)),
+      expectedCaseName: "poundSourceLocation",
+      expectedTypeDeclarationArchetype: nil,
+      expectedModifierNames: nil,
+      expectedVisibilityLevel: nil,
+      expectedAttributeCount: nil,
+      expectedTypeName: nil
+    ),
+    ConcreteDeclarationFixture(
+      declaration: try #require(sourceFile.firstSyntaxElement(ofType: PrecedenceGroupDeclSyntax.self)),
+      expectedCaseName: "precedenceGroup",
+      expectedTypeDeclarationArchetype: nil,
+      expectedModifierNames: [],
+      expectedVisibilityLevel: nil,
+      expectedAttributeCount: 0,
+      expectedTypeName: nil
+    ),
+    ConcreteDeclarationFixture(
+      declaration: try #require(sourceFile.firstSyntaxElement(ofType: ProtocolDeclSyntax.self)),
+      expectedCaseName: "protocol",
+      expectedTypeDeclarationArchetype: nil,
+      expectedModifierNames: [],
+      expectedVisibilityLevel: nil,
+      expectedAttributeCount: 0,
+      expectedTypeName: nil
+    ),
+    ConcreteDeclarationFixture(
+      declaration: try #require(sourceFile.firstSyntaxElement(ofType: StructDeclSyntax.self)),
+      expectedCaseName: "struct",
+      expectedTypeDeclarationArchetype: "struct",
+      expectedModifierNames: [],
+      expectedVisibilityLevel: nil,
+      expectedAttributeCount: 0,
+      expectedTypeName: "Pair"
+    ),
+    ConcreteDeclarationFixture(
+      declaration: try #require(sourceFile.firstSyntaxElement(ofType: SubscriptDeclSyntax.self)),
+      expectedCaseName: "subscript",
+      expectedTypeDeclarationArchetype: nil,
+      expectedModifierNames: [],
+      expectedVisibilityLevel: nil,
+      expectedAttributeCount: 0,
+      expectedTypeName: nil
+    ),
+    ConcreteDeclarationFixture(
+      declaration: try #require(sourceFile.firstSyntaxElement(ofType: TypeAliasDeclSyntax.self)),
+      expectedCaseName: "typealias",
+      expectedTypeDeclarationArchetype: nil,
+      expectedModifierNames: [],
+      expectedVisibilityLevel: nil,
+      expectedAttributeCount: 0,
+      expectedTypeName: nil
+    ),
+    ConcreteDeclarationFixture(
+      declaration: try #require(sourceFile.firstSyntaxElement(ofType: VariableDeclSyntax.self)),
+      expectedCaseName: "variable",
+      expectedTypeDeclarationArchetype: nil,
+      expectedModifierNames: [],
+      expectedVisibilityLevel: nil,
+      expectedAttributeCount: 0,
+      expectedTypeName: nil
+    )
+  ]
+}
+
+private extension ConcreteDeclSyntax {
+  
+  var caseName: String {
+    switch self {
+    case .accessor:
+      "accessor"
+    case .actor:
+      "actor"
+    case .associatedtype:
+      "associatedtype"
+    case .class:
+      "class"
+    case .deinitializer:
+      "deinitializer"
+    case .editorPlaceholder:
+      "editorPlaceholder"
+    case .enumCase:
+      "enumCase"
+    case .enum:
+      "enum"
+    case .extension:
+      "extension"
+    case .function:
+      "function"
+    case .ifConfig:
+      "ifConfig"
+    case .import:
+      "import"
+    case .initializer:
+      "initializer"
+    case .macro:
+      "macro"
+    case .macroExpansion:
+      "macroExpansion"
+    case .missing:
+      "missing"
+    case .operator:
+      "operator"
+    case .poundSourceLocation:
+      "poundSourceLocation"
+    case .precedenceGroup:
+      "precedenceGroup"
+    case .protocol:
+      "protocol"
+    case .struct:
+      "struct"
+    case .subscript:
+      "subscript"
+    case .typealias:
+      "typealias"
+    case .variable:
+      "variable"
+    }
+  }
+  
+}
+
+private extension ConcreteTypeDeclaration {
+  
+  var caseName: String {
+    switch self {
+    case .actor:
+      "actor"
+    case .class:
+      "class"
+    case .enum:
+      "enum"
+    case .struct:
+      "struct"
+    }
+  }
+  
+  var storedPropertyDescriptorsForDataTypes: [StoredPropertyDescriptor]? {
+    switch self {
+    case .actor(let decl):
+      decl.storedPropertyDescriptors
+    case .class(let decl):
+      decl.storedPropertyDescriptors
+    case .enum:
+      nil
+    case .struct(let decl):
+      decl.storedPropertyDescriptors
+    }
+  }
+  
+}

--- a/Tests/MacroToolboxTests/Model/MacroAttachmentRequirement+ArchetypeEquivalence+Tests.swift
+++ b/Tests/MacroToolboxTests/Model/MacroAttachmentRequirement+ArchetypeEquivalence+Tests.swift
@@ -11,12 +11,12 @@ import MacroToolboxTestSupport
   )
 )
 func testMacroAttachmentRequirementTypeDeclarationArchetypeConversionEquivalence_unspecified() {
-  
+
   let typeAttachmentRequirement = MacroAttachmentRequirement<TypeDeclarationArchetype>.unspecified
   let attachmentRequirement = MacroAttachmentRequirement<DeclarationArchetype>.unspecified
-  
+
   let equivalentAttachmentRequirement = typeAttachmentRequirement.equivalentDeclarationArchetypeRequirement
-  
+
   for probe in TypeDeclarationArchetype.allCases {
     #expect(
       typeAttachmentRequirement.isCompatible(with: probe)
@@ -24,7 +24,7 @@ func testMacroAttachmentRequirementTypeDeclarationArchetypeConversionEquivalence
       attachmentRequirement.isCompatible(with: probe.declarationArchetype)
     )
   }
-  
+
   for probe in DeclarationArchetype.allCases {
     #expect(
       equivalentAttachmentRequirement.isCompatible(with: probe)
@@ -50,13 +50,13 @@ func testMacroAttachmentRequirementTypeDeclarationArchetypeConversionEquivalence
   let typeAttachmentRequirement = MacroAttachmentRequirement<TypeDeclarationArchetype>.exactly(
     typeDeclarationArchetype
   )
-  
+
   let attachmentRequirement = MacroAttachmentRequirement<DeclarationArchetype>.exactly(
     typeDeclarationArchetype.declarationArchetype
   )
-  
+
   let equivalentAttachmentRequirement = typeAttachmentRequirement.equivalentDeclarationArchetypeRequirement
-  
+
   for probe in TypeDeclarationArchetype.allCases {
     #expect(
       typeAttachmentRequirement.isCompatible(with: probe)
@@ -64,7 +64,7 @@ func testMacroAttachmentRequirementTypeDeclarationArchetypeConversionEquivalence
       attachmentRequirement.isCompatible(with: probe.declarationArchetype)
     )
   }
-  
+
   for probe in DeclarationArchetype.allCases {
     #expect(
       equivalentAttachmentRequirement.isCompatible(with: probe)
@@ -90,13 +90,13 @@ func testMacroAttachmentRequirementTypeDeclarationArchetypeConversionEquivalence
   let typeAttachmentRequirement = MacroAttachmentRequirement<TypeDeclarationArchetype>.mustBeOneOf([
       typeDeclarationArchetype
   ])
-  
+
   let attachmentRequirement = MacroAttachmentRequirement<DeclarationArchetype>.mustBeOneOf([
     typeDeclarationArchetype.declarationArchetype
   ])
-  
+
   let equivalentAttachmentRequirement = typeAttachmentRequirement.equivalentDeclarationArchetypeRequirement
-  
+
   for probe in TypeDeclarationArchetype.allCases {
     #expect(
       typeAttachmentRequirement.isCompatible(with: probe)
@@ -104,7 +104,7 @@ func testMacroAttachmentRequirementTypeDeclarationArchetypeConversionEquivalence
       attachmentRequirement.isCompatible(with: probe.declarationArchetype)
     )
   }
-  
+
   for probe in DeclarationArchetype.allCases {
     #expect(
       equivalentAttachmentRequirement.isCompatible(with: probe)
@@ -130,7 +130,7 @@ func testMacroAttachmentRequirementTypeDeclarationArchetypeConversionEquivalence
   let typeAttachmentRequirement = MacroAttachmentRequirement<TypeDeclarationArchetype>.anythingBut([
       typeDeclarationArchetype
   ])
-  
+
   let attachmentRequirement = MacroAttachmentRequirement<DeclarationArchetype>.anythingBut(
     DeclarationArchetype
       .setOfAllCases
@@ -141,9 +141,9 @@ func testMacroAttachmentRequirementTypeDeclarationArchetypeConversionEquivalence
           .setMap(\.declarationArchetype)
       )
   )
-  
+
   let equivalentAttachmentRequirement = typeAttachmentRequirement.equivalentDeclarationArchetypeRequirement
-  
+
   for probe in TypeDeclarationArchetype.allCases {
     #expect(
       typeAttachmentRequirement.isCompatible(with: probe)
@@ -151,12 +151,79 @@ func testMacroAttachmentRequirementTypeDeclarationArchetypeConversionEquivalence
       attachmentRequirement.isCompatible(with: probe.declarationArchetype)
     )
   }
-  
+
   for probe in DeclarationArchetype.allCases {
     #expect(
       equivalentAttachmentRequirement.isCompatible(with: probe)
       ==
       attachmentRequirement.isCompatible(with: probe)
     )
+  }
+}
+
+@Test(
+  "`MacroAttachmentRequirement` descriptions and direct compatibility",
+  .tags(.macroAttachmentRequirement)
+)
+func testMacroAttachmentRequirementDescriptionsAndDirectCompatibility() {
+  // Hand-written examples: each requirement case should describe itself, report
+  // whether a probe value is accepted, and keep empty-set requirements marked as
+  // internally inconsistent.
+  let unspecified = MacroAttachmentRequirement<Int>.unspecified
+  let exact = MacroAttachmentRequirement<Int>.exactly(2)
+  let oneOf = MacroAttachmentRequirement<Int>.mustBeOneOf([1, 3])
+  let anythingBut = MacroAttachmentRequirement<Int>.anythingBut([4])
+  let mustNotBe = MacroAttachmentRequirement<Int>.mustNotBe(2)
+
+  #expect(unspecified.description == ".unspecified")
+  #expect(exact.description == ".exactly(2)")
+  #expect(oneOf.description.contains(".mustBeOneOf"))
+  #expect(anythingBut.description.contains(".anythingBut"))
+  #expect(unspecified.debugDescription == "MacroAttachmentRequirement.unspecified")
+  #expect(exact.debugDescription == "MacroAttachmentRequirement.exactly(2)")
+  #expect(oneOf.debugDescription.contains("MacroAttachmentRequirement.mustBeOneOf"))
+  #expect(anythingBut.debugDescription.contains("MacroAttachmentRequirement.anythingBut"))
+  #expect(unspecified.isCompatible(with: 99))
+  #expect(exact.isCompatible(with: 2))
+  #expect(!exact.isCompatible(with: 1))
+  #expect(oneOf.isCompatible(with: 3))
+  #expect(!oneOf.isCompatible(with: 2))
+  #expect(anythingBut.isCompatible(with: 2))
+  #expect(!anythingBut.isCompatible(with: 4))
+  #expect(mustNotBe.isCompatible(with: 1))
+  #expect(!mustNotBe.isCompatible(with: 2))
+  #expect(unspecified.hasConsistentInternalState)
+  #expect(exact.hasConsistentInternalState)
+  #expect(oneOf.hasConsistentInternalState)
+  #expect(anythingBut.hasConsistentInternalState)
+  #expect(!MacroAttachmentRequirement<Int>.mustBeOneOf([]).hasConsistentInternalState)
+  #expect(!MacroAttachmentRequirement<Int>.anythingBut([]).hasConsistentInternalState)
+}
+
+@Test(
+  "`MacroAttachmentRequirement.mapRequirements` preserves compatibility",
+  .tags(.macroAttachmentRequirement)
+)
+func testMacroAttachmentRequirementMapRequirementsPreservesCompatibility() throws {
+  // Property-style test: mapping requirements into another hashable domain should
+  // preserve compatibility for every requirement shape when probes are mapped by
+  // the same transformation.
+  let requirements: [MacroAttachmentRequirement<Int>] = [
+    .unspecified,
+    .exactly(2),
+    .mustBeOneOf([1, 3]),
+    .anythingBut([4])
+  ]
+
+  for requirement in requirements {
+    let mapped = requirement.mapRequirements { "value-\($0)" }
+
+    for probe in [1, 2, 3, 4, 5] {
+      #expect(
+        mapped.isCompatible(with: "value-\(probe)")
+        ==
+        requirement.isCompatible(with: probe)
+      )
+    }
   }
 }

--- a/Tests/MacroToolboxTests/Model/TypeDeclarationArchetype+Tests.swift
+++ b/Tests/MacroToolboxTests/Model/TypeDeclarationArchetype+Tests.swift
@@ -135,3 +135,22 @@ func testTypeDeclarationArchetypeIsActorClassOrStruct(
     [.actor, .class, .struct].contains(archetype)
   )
 }
+
+@Test(
+  "`TypeDeclarationArchetype.isNotEnumOrProtocol`",
+  .tags(.typeDeclarationArchetype),
+  arguments: TypeDeclarationArchetype.allCases
+)
+func testTypeDeclarationArchetypeIsNotEnumOrProtocol(
+  archetype: TypeDeclarationArchetype
+) {
+  // Property-style test: this spelling is intentionally equivalent to the
+  // actor/class/struct predicate, so every case should match that independent
+  // membership check.
+  #expect(
+    archetype.isNotEnumOrProtocol
+    ==
+    [.actor, .class, .struct].contains(archetype)
+  )
+  #expect(archetype.isNotEnumOrProtocol == archetype.isActorClassOrStruct)
+}

--- a/Tests/MacroToolboxTests/Model/VisibilityLevel+Syntax+Tests.swift
+++ b/Tests/MacroToolboxTests/Model/VisibilityLevel+Syntax+Tests.swift
@@ -1,3 +1,4 @@
+import SwiftSyntax
 import Testing
 import MacroToolboxTestSupport
 @testable import MacroToolbox
@@ -60,4 +61,56 @@ func testVisibilityLevelKeywordRepresentationRoundTrip(
     ==
     VisibilityLevel(keywordRepresentation: visibilityLevel.keywordRepresentation)
   )
+}
+
+@Test(
+  "`VisibilityLevel` syntax conveniences render tokens and source strings",
+  .tags(
+    .visibilityLevel,
+    .syntaxInteroperation,
+    .keyword
+  )
+)
+func testVisibilityLevelSyntaxConveniencesRenderTokensAndSourceStrings() {
+  // Hand-written examples: visibility levels should produce keyword tokens,
+  // token kinds, and source strings suitable for generated Swift declarations.
+  let token = VisibilityLevel.public.tokenRepresentation(
+    leadingTrivia: .spaces(1),
+    trailingTrivia: .spaces(1)
+  )
+  let initializedToken = TokenSyntax(
+    leadingTrivia: .spaces(1),
+    visibilityLevel: .public,
+    trailingTrivia: .spaces(1)
+  )
+
+  #expect(token.description == " public ")
+  #expect(initializedToken.description == " public ")
+  #expect(VisibilityLevel.public.tokenKindRepresentation == .keyword(.public))
+  #expect(TokenKind(visibilityLevel: .public) == .keyword(.public))
+  #expect(Keyword(visibilityLevel: .public) == .public)
+  #expect(VisibilityLevel.public.sourceCodeStringRepresentation == "public")
+  #expect(VisibilityLevel(keywordRepresentation: .func) == nil)
+  #expect(TokenKind.identifier("public").visibilityLevel == nil)
+}
+
+@Test(
+  "`VisibilityLevel` syntax conveniences round-trip all cases",
+  .tags(
+    .visibilityLevel,
+    .syntaxInteroperation,
+    .keyword
+  ),
+  arguments: VisibilityLevel.allCases
+)
+func testVisibilityLevelSyntaxConveniencesRoundTripAllCases(
+  visibilityLevel: VisibilityLevel
+) {
+  // Property-style test: every visibility level should have a mutually
+  // consistent keyword, token kind, token syntax, and source-string spelling.
+  #expect(Keyword(visibilityLevel: visibilityLevel) == visibilityLevel.keywordRepresentation)
+  #expect(TokenKind(visibilityLevel: visibilityLevel).visibilityLevel == visibilityLevel)
+  #expect(TokenSyntax(visibilityLevel: visibilityLevel).tokenKind.visibilityLevel == visibilityLevel)
+  #expect(visibilityLevel.tokenRepresentation().text == visibilityLevel.sourceCodeStringRepresentation)
+  #expect(visibilityLevel.sourceCodeStringRepresentation == visibilityLevel.caseNameWithoutLeadingDot)
 }

--- a/Tests/MacroToolboxTests/Model/VisibilityLevel+Tests.swift
+++ b/Tests/MacroToolboxTests/Model/VisibilityLevel+Tests.swift
@@ -55,8 +55,46 @@ func testVisibilityLevelCaseNameWithoutLeadingDotUniqueness() {
       VisibilityLevel
         .allCases
         .lazy
-        .map(\.caseNameWithoutLeadingDot)
+      .map(\.caseNameWithoutLeadingDot)
     ).count
   )
 }
 
+@Test(
+  "`VisibilityLevel` ordering and privacy tier semantics",
+  .tags(.visibilityLevel)
+)
+func testVisibilityLevelOrderingAndPrivacyTierSemantics() {
+  // Hand-written examples: access levels are ordered from most restrictive to
+  // least restrictive by their raw value, and only Swift's private tier is
+  // classified as private-tier visibility.
+  #expect(VisibilityLevel.private < .fileprivate)
+  #expect(VisibilityLevel.fileprivate < .internal)
+  #expect(VisibilityLevel.public < .open)
+  #expect(VisibilityLevel.private.isWithinPrivateTier)
+  #expect(VisibilityLevel.fileprivate.isWithinPrivateTier)
+  #expect(!VisibilityLevel.internal.isWithinPrivateTier)
+}
+
+@Test(
+  "`VisibilityLevel` ordering matches raw-value ordering",
+  .tags(.visibilityLevel)
+)
+func testVisibilityLevelOrderingMatchesRawValueOrdering() {
+  // Property-style test: comparison and privacy-tier classification should match
+  // the model's independent raw-value ordering and the explicit private set for
+  // every case.
+  let orderedByRawValue = VisibilityLevel.allCases.sorted { lhs, rhs in
+    lhs.rawValue < rhs.rawValue
+  }
+
+  #expect(VisibilityLevel.allCases.sorted() == orderedByRawValue)
+
+  for visibilityLevel in VisibilityLevel.allCases {
+    #expect(
+      visibilityLevel.isWithinPrivateTier
+      ==
+      [.private, .fileprivate].contains(visibilityLevel)
+    )
+  }
+}

--- a/Tests/MacroToolboxTests/Support/CoreSupport+Tests.swift
+++ b/Tests/MacroToolboxTests/Support/CoreSupport+Tests.swift
@@ -235,6 +235,37 @@ func testStringTupleStringificationHelpers() {
   #expect(Optional<String>.none.argumentLabelRepresentation == "")
   #expect(Optional("").argumentLabelRepresentation == "")
   #expect(Optional("value").argumentLabelRepresentation == "value: ")
+
+  // Single-element variadic packs: Swift represents `(repeat each T)` as the
+  // scalar element type when the pack has exactly one element, so the
+  // initializers must iterate the pack directly rather than relying on
+  // `Mirror`-based child enumeration, which would yield zero children for a
+  // scalar like `Int` and silently drop the argument.
+  #expect(
+    String(forCaption: "solo", describingTuple: (1))
+    ==
+    "(solo: 1)"
+  )
+  #expect(String(describingTuple: (1)) == "(1)")
+
+  // Labeled single-element packs cannot be expressed with literal tuple
+  // syntax — Swift cannot disambiguate `(String, T)` between a 1-element
+  // labeled pack and a 2-element non-labeled pack — so the regression is
+  // exercised through generic wrappers that forward a real pack expansion.
+  #expect(forwardingDescribingLabeledTuple(("x", 1)) == "(x: 1)")
+  #expect(forwardingReflectingLabeledTuple(("x", "one")) == #"(x: "one")"#)
+}
+
+private func forwardingDescribingLabeledTuple<each T>(
+  _ labeledValues: repeat (String, each T)
+) -> String {
+  String(describingLabeledTuple: (repeat each labeledValues))
+}
+
+private func forwardingReflectingLabeledTuple<each T>(
+  _ labeledValues: repeat (String, each T)
+) -> String {
+  String(reflectingLabeledTuple: (repeat each labeledValues))
 }
 
 @Test("String constructor stringification helpers preserve labels and arguments")
@@ -250,9 +281,24 @@ func testStringConstructorStringificationHelpersPreserveLabelsAndArguments() {
     forConstructorOf: TupleStringificationFixture.self,
     unlabeledArguments: (1, "two", 3)
   )
-  
+
   #expect(labeled.hasSuffix(#"TupleStringificationFixture(1, label: "two", 3)"#))
   #expect(unlabeled.hasSuffix(#"TupleStringificationFixture(1, "two", 3)"#))
+
+  // Single-element packs must also reach the constructor-string initializers
+  // without losing the argument, since variadic packs collapse to the scalar
+  // type for one element. The labeled constructor takes pairs whose first
+  // component is `String?`, so Swift cannot disambiguate a literal pair from
+  // a 2-element pack of non-labeled values — the regression is exercised via
+  // a generic wrapper that forwards a real pack expansion.
+  let singleLabeled = forwardingForConstructorArgument(("label", 1))
+  let singleUnlabeled = String(
+    forConstructorOf: TupleStringificationFixture.self,
+    unlabeledArguments: (1)
+  )
+
+  #expect(singleLabeled.hasSuffix("TupleStringificationFixture(label: 1)"))
+  #expect(singleUnlabeled.hasSuffix("TupleStringificationFixture(1)"))
   
   for label in [String?.none, "", "value"] {
     let expected = label.map { $0.isEmpty ? "" : "\($0): " } ?? ""
@@ -277,6 +323,15 @@ func testStringConstructorStringificationHelpersPreserveLabelsAndArguments() {
     from: 1
   )
   #expect(missingParsedLabel == nil)
+}
+
+private func forwardingForConstructorArgument<each T>(
+  _ labeledValues: repeat (String?, each T)
+) -> String {
+  String(
+    forConstructorOf: TupleStringificationFixture.self,
+    arguments: (repeat each labeledValues)
+  )
 }
 
 private enum SupportExampleCase: String, CaseIterable, MacroToolboxCaseNameAwareEnumeration, CustomStringConvertible, CustomDebugStringConvertible {

--- a/Tests/MacroToolboxTests/Support/CoreSupport+Tests.swift
+++ b/Tests/MacroToolboxTests/Support/CoreSupport+Tests.swift
@@ -1,0 +1,308 @@
+import Testing
+import MacroToolboxTestSupport
+@testable import MacroToolbox
+
+@Test("Case-name aware enumeration defaults")
+func testCaseNameAwareEnumerationDefaults() {
+  // Hand-written example: a raw-string enum should derive the bare case name,
+  // the dotted case spelling, and the display descriptions from the same case.
+  #expect(SupportExampleCase.alpha.caseNameWithoutLeadingDot == "alpha")
+  #expect(SupportExampleCase.alpha.caseNameWithLeadingDot == ".alpha")
+  #expect(SupportExampleCase.alpha.description == ".alpha")
+  #expect(SupportExampleCase.alpha.debugDescription.hasSuffix(".alpha"))
+  
+  // Hand-written example: CodingKey conformers use the dedicated overloads
+  // that avoid ambiguity with CodingKey's own descriptive requirements.
+  #expect(SupportExampleCodingKey.beta.description == ".beta")
+  #expect(SupportExampleCodingKey.beta.debugDescription.hasSuffix(".beta"))
+}
+
+@Test("Case-name aware enumeration defaults derive from raw values")
+func testCaseNameAwareEnumerationDefaultsDeriveFromRawValues() {
+  // Property-style test: every case's derived spellings must be a mechanical
+  // transformation of its raw value, which is the invariant the protocol
+  // extension promises for raw-string enumerations.
+  for example in SupportExampleCase.allCases {
+    #expect(example.caseNameWithoutLeadingDot == example.rawValue)
+    #expect(example.caseNameWithLeadingDot == ".\(example.rawValue)")
+    #expect(example.description == example.caseNameWithLeadingDot)
+    #expect(example.debugDescription.hasSuffix(example.caseNameWithLeadingDot))
+  }
+  
+  for example in SupportExampleCodingKey.allCases {
+    #expect(example.caseNameWithoutLeadingDot == example.rawValue)
+    #expect(example.description == example.caseNameWithLeadingDot)
+    #expect(example.debugDescription.hasSuffix(example.caseNameWithLeadingDot))
+  }
+}
+
+@Test("Collection unless-empty helper")
+func testCollectionUnlessEmptyHelper() {
+  // Hand-written example: a non-empty collection survives unchanged, while an
+  // empty collection becomes nil so callers can express absence directly.
+  #expect([1, 2, 3].unlessEmpty == [1, 2, 3])
+  #expect([Int]().unlessEmpty == nil)
+}
+
+@Test("Collection unless-empty helper matches emptiness")
+func testCollectionUnlessEmptyHelperMatchesEmptiness() {
+  // Property-style test: for several collection sizes, the helper's optionality
+  // is exactly the collection's `isEmpty` value and the payload is unchanged.
+  for values in [[Int](), [1], [1, 2, 3]] {
+    let result = values.unlessEmpty
+    
+    #expect((result == nil) == values.isEmpty)
+    #expect(result ?? [] == values)
+  }
+}
+
+@Test("Optional ensured-value helper")
+func testOptionalEnsuredValueHelper() {
+  // Hand-written example: an existing value must be returned without invoking
+  // the fallback, while nil must store and return the fallback.
+  var existing: Int? = 7
+  var fallbackWasEvaluated = false
+  let existingValue = existing.ensuredValue(
+    guaranteedBy: {
+      fallbackWasEvaluated = true
+      return 9
+    }()
+  )
+  
+  var missing: Int? = nil
+  let missingValue = missing.ensuredValue(guaranteedBy: 11)
+  
+  #expect(existingValue == 7)
+  #expect(existing == 7)
+  #expect(!fallbackWasEvaluated)
+  #expect(missingValue == 11)
+  #expect(missing == 11)
+}
+
+@Test("Automatic source locations preserve explicit coordinates")
+func testAutomaticSourceLocationsPreserveExplicitCoordinates() {
+  // Hand-written example: the temporary test-support shim should pass through
+  // explicit file and coordinate values to Testing's SourceLocation initializer.
+  let location = Testing.SourceLocation.automatic(
+    fileID: "MacroToolboxTests/CoreSupport",
+    filePath: "/tmp/CoreSupport.swift",
+    line: 12,
+    column: 34
+  )
+  
+  #expect(location.fileID == "MacroToolboxTests/CoreSupport")
+  #expect(location.filePath == "/tmp/CoreSupport.swift")
+  #expect(location.line == 12)
+  #expect(location.column == 34)
+}
+
+@Test("Optional ensured-value helper is stable after insertion")
+func testOptionalEnsuredValueHelperIsStableAfterInsertion() {
+  // Property-style test: after the first fallback insertion, repeated calls
+  // must keep returning the stored value rather than replacing it.
+  for fallback in [0, 1, 42] {
+    var value: Int? = nil
+    
+    #expect(value.ensuredValue(guaranteedBy: fallback) == fallback)
+    #expect(value.ensuredValue(guaranteedBy: fallback + 1) == fallback)
+    #expect(value == fallback)
+  }
+}
+
+@Test("Sequence support helpers")
+func testSequenceSupportHelpers() {
+  // Hand-written examples: each helper is pinned to the standard-library
+  // operation it abbreviates so the intended behavior stays obvious.
+  #expect([1, 3, 4].anySatisfy { $0.isMultiple(of: 2) })
+  #expect(![1, 3, 5].anySatisfy { $0.isMultiple(of: 2) })
+  #expect([1, 2, 3].firstNonNilValue { $0 > 1 ? "\($0)" : nil } == "2")
+  #expect([Int?](arrayLiteral: 1, nil, 3).dropNilElements() == [1, 3])
+}
+
+@Test("Sequence support helpers match standard-library equivalents")
+func testSequenceSupportHelpersMatchStandardLibraryEquivalents() {
+  // Property-style test: across several sequences and predicates, these helpers
+  // must match the standard-library compositions they are replacing.
+  let samples = [
+    [Int](),
+    [1],
+    [1, 2, 3, 4],
+    [5, 7, 9]
+  ]
+  
+  for values in samples {
+    for divisor in [2, 3, 5] {
+      #expect(
+        values.anySatisfy { $0.isMultiple(of: divisor) }
+        ==
+        values.contains { $0.isMultiple(of: divisor) }
+      )
+    }
+    
+    #expect(
+      values.firstNonNilValue { $0 > 2 ? "\($0)" : nil }
+      ==
+      values.compactMap { $0 > 2 ? "\($0)" : nil }.first
+    )
+  }
+  
+  for values in [
+    [Int?](),
+    [nil, 1, nil, 2],
+    [3, 4, 5]
+  ] {
+    #expect(values.dropNilElements() == values.compactMap { $0 })
+  }
+}
+
+@Test("Set set-map helper")
+func testSetMapHelper() {
+  // Hand-written example: mapping a non-empty set transforms all elements into
+  // a set, and mapping an empty set returns an empty set without invoking work.
+  #expect(Set([1, 2, 3]).setMap { "\($0)" } == Set(["1", "2", "3"]))
+  #expect(Set<Int>().setMap { "\($0)" } == [])
+}
+
+@Test("Set set-map helper matches Set over mapped values")
+func testSetMapHelperMatchesSetOverMappedValues() {
+  // Property-style test: with and without the uniqueness capacity hint, the
+  // result must equal constructing a Set from the standard mapped sequence.
+  for values in [
+    Set<Int>(),
+    Set([1]),
+    Set([1, 2, 3])
+  ] {
+    #expect(
+      values.setMap(expectUnique: true) { $0 % 2 }
+      ==
+      Set(values.map { $0 % 2 })
+    )
+    #expect(
+      values.setMap(expectUnique: false) { $0 % 2 }
+      ==
+      Set(values.map { $0 % 2 })
+    )
+  }
+}
+
+@Test("String first-character lowercasing")
+func testStringFirstCharacterLowercasing() {
+  // Hand-written examples: the helper should leave empty strings empty and only
+  // lowercase the first character of both String and Substring inputs.
+  #expect(String(lowercasingFirstCharacterOf: "") == "")
+  #expect(String(lowercasingFirstCharacterOf: "Widget") == "widget")
+  #expect(String(lowercasingFirstCharacterOf: "URLValue".dropFirst()) == "rLValue")
+}
+
+@Test("String first-character lowercasing matches manual construction")
+func testStringFirstCharacterLowercasingMatchesManualConstruction() {
+  // Property-style test: for several ASCII spellings, the helper should match
+  // manually lowercasing the first character and appending the untouched suffix.
+  for value in ["", "A", "URLValue", "already", "1Number"] {
+    let expected: String
+    if value.isEmpty {
+      expected = ""
+    } else {
+      let splitIndex = value.index(after: value.startIndex)
+      expected = "\(value.prefix(upTo: splitIndex).lowercased())\(value.suffix(from: splitIndex))"
+    }
+    
+    #expect(String(lowercasingFirstCharacterOf: value) == expected)
+    #expect(String(lowercasingFirstCharacterOf: value[...]) == expected)
+  }
+}
+
+@Test("String tuple stringification helpers")
+func testStringTupleStringificationHelpers() {
+  // Hand-written examples: each tuple-string initializer gets a two-element
+  // sample so both first-element and separator paths are pinned explicitly.
+  #expect(
+    String(forCaption: "point", describingTuple: (1, "two"))
+    ==
+    "(point: 1, two)"
+  )
+  #expect(String(describingTuple: (1, "two")) == "(1, two)")
+  #expect(
+    String(describingLabeledTuple: (("x", 1), ("y", "two")))
+    ==
+    "(x: 1, y: two)"
+  )
+  #expect(
+    String(reflectingLabeledTuple: (("x", "one"), ("y", 2)))
+    ==
+    #"(x: "one", y: 2)"#
+  )
+  #expect(Optional<String>.none.argumentLabelRepresentation == "")
+  #expect(Optional("").argumentLabelRepresentation == "")
+  #expect(Optional("value").argumentLabelRepresentation == "value: ")
+}
+
+@Test("String constructor stringification helpers preserve labels and arguments")
+func testStringConstructorStringificationHelpersPreserveLabelsAndArguments() {
+  // Property-style test: constructor spellings are checked across labeled,
+  // unlabeled, nil-label, and empty-label arguments so label insertion stays
+  // consistent with `argumentLabelRepresentation`.
+  let labeled = String(
+    forConstructorOf: TupleStringificationFixture.self,
+    arguments: ((nil, 1), ("label", "two"), ("", 3))
+  )
+  let unlabeled = String(
+    forConstructorOf: TupleStringificationFixture.self,
+    unlabeledArguments: (1, "two", 3)
+  )
+  
+  #expect(labeled.hasSuffix(#"TupleStringificationFixture(1, label: "two", 3)"#))
+  #expect(unlabeled.hasSuffix(#"TupleStringificationFixture(1, "two", 3)"#))
+  
+  for label in [String?.none, "", "value"] {
+    let expected = label.map { $0.isEmpty ? "" : "\($0): " } ?? ""
+    #expect(label.argumentLabelRepresentation == expected)
+  }
+  
+  // Hand-written edge cases: the reflection fallbacks should preserve a useful
+  // description when a helper is called with a value that is not a labeled pair.
+  #expect(
+    String.constructorArgumentComponents(reflecting: (1, ("label", 2)))
+    ==
+    ["1", "label: 2"]
+  )
+  #expect(
+    String.tuplePairComponents(from: (1, ("x", 2))) { pair in
+      "\(pair.label)=\(pair.value)"
+    }
+    ==
+    ["1", "x=2"]
+  )
+  let missingParsedLabel: String?? = String.parsedConstructorArgumentLabel(
+    from: 1
+  )
+  #expect(missingParsedLabel == nil)
+}
+
+private enum SupportExampleCase: String, CaseIterable, MacroToolboxCaseNameAwareEnumeration, CustomStringConvertible, CustomDebugStringConvertible {
+  case alpha
+  case beta
+}
+
+private enum SupportExampleCodingKey: String, CaseIterable, CodingKey, MacroToolboxCaseNameAwareEnumeration {
+  case alpha
+  case beta
+  
+  var stringValue: String {
+    rawValue
+  }
+  
+  init?(stringValue: String) {
+    self.init(rawValue: stringValue)
+  }
+  
+  var intValue: Int? {
+    nil
+  }
+  
+  init?(intValue: Int) {
+    nil
+  }
+}
+
+private struct TupleStringificationFixture {}

--- a/Tests/MacroToolboxTests/Support/SyntaxProtocolConvenience+Tests.swift
+++ b/Tests/MacroToolboxTests/Support/SyntaxProtocolConvenience+Tests.swift
@@ -1,0 +1,267 @@
+import SwiftSyntax
+import Testing
+@testable import MacroToolbox
+
+@Test("Generated syntax-element cast conveniences")
+func testGeneratedSyntaxElementCastConveniences() throws {
+  // Hand-written example: a struct declaration gives one known-positive cast
+  // and one known-negative cast, pinning the intended spelling and semantics
+  // for the generated `as*`/`is*` conveniences.
+  let structDecl = try StructDeclSyntax.onlyParsed(
+    from: "public struct Widget { var count: Int }"
+  )
+  let syntax = Syntax(structDecl)
+  
+  #expect(syntax.isStructDeclSyntax)
+  #expect(!syntax.isEnumDeclSyntax)
+  #expect(syntax.asStructDeclSyntax?.name.text == "Widget")
+  #expect(syntax.asSyntaxElement(StructDeclSyntax.self)?.name.text == "Widget")
+  #expect(syntax.isSyntaxElement(StructDeclSyntax.self))
+}
+
+@Test("Syntax tree search conveniences")
+func testSyntaxTreeSearchConveniences() throws {
+  // Hand-written example: the first-match helper should find the stored
+  // property we can name directly, while the all-match helper should preserve
+  // enough traversal coverage to find a token nested inside the declaration.
+  let sourceFile = try SourceFileSyntax.onlyParsed(
+    from: "public struct Widget { var count: Int }"
+  )
+  
+  let storedProperty = sourceFile.firstSyntaxElement(
+    ofType: VariableDeclSyntax.self
+  )
+  
+  #expect(storedProperty?.variableNameIfStoredProperty == "count")
+  #expect(
+    sourceFile
+      .allSyntaxElements(ofType: TokenSyntax.self)
+      .contains { $0.text == "Widget" }
+  )
+}
+
+@Test("Syntax tree search conveniences agree with all-match traversal")
+func testSyntaxTreeSearchConveniencesAgreeWithAllMatchTraversal() throws {
+  // Property-style test: for several parsed programs and syntax categories,
+  // `firstSyntaxElement` must be exactly the first element returned by
+  // `allSyntaxElements`, and every all-match result must have the requested
+  // type according to SwiftSyntax's generic cast.
+  let sourceFiles = try [
+    "struct Widget { var count: Int }",
+    "enum Choice { case first(Int), second }",
+    "func value() -> Int { return 1 }"
+  ].map {
+    try SourceFileSyntax.onlyParsed(from: $0)
+  }
+  
+  for sourceFile in sourceFiles {
+    assertTreeSearchProperty(sourceFile, StructDeclSyntax.self)
+    assertTreeSearchProperty(sourceFile, EnumDeclSyntax.self)
+    assertTreeSearchProperty(sourceFile, FunctionDeclSyntax.self)
+    assertTreeSearchProperty(sourceFile, VariableDeclSyntax.self)
+    assertTreeSearchProperty(sourceFile, IdentifierTypeSyntax.self)
+    assertTreeSearchProperty(sourceFile, TokenSyntax.self)
+  }
+}
+
+@Test("Source parsing conveniences cover major syntax categories")
+func testSourceParsingConveniencesCoverMajorSyntaxCategories() throws {
+  // Hand-written examples: the parser conveniences are intentionally broad,
+  // so this pins one representative syntax node from each major SwiftSyntax
+  // category the type-erasure helpers also support.
+  let declaration = try StructDeclSyntax.onlyParsed(from: "struct Example {}")
+  let expression = try BooleanLiteralExprSyntax.firstParsed(from: "let flag = true")
+  let pattern = try IdentifierPatternSyntax.firstParsed(from: "let value = 1")
+  let statement = try ReturnStmtSyntax.firstParsed(
+    from: "func value() -> Int { return 1 }"
+  )
+  let type = try IdentifierTypeSyntax.firstParsed(from: "let value: Int = 1")
+  
+  #expect(declaration.name.text == "Example")
+  #expect(expression.representedBooleanLiteralValue == true)
+  #expect(pattern.identifier.text == "value")
+  #expect(statement.returnKeyword.text == "return")
+  #expect(type.name.text == "Int")
+}
+
+@Test("Source parsing conveniences expose successful and failing parse properties")
+func testSourceParsingConveniencesExposeSuccessfulAndFailingParseProperties() throws {
+  // Property-style test: for each representative source/type pair, all four
+  // parsing entry points must agree on the same syntax text; for failure cases,
+  // the helpers must report `MacroExpansionFailure` instead of silently
+  // returning an unrelated node.
+  try assertSourceParsingProperty(
+    "declaration",
+    source: "struct Example {}",
+    validate: { source in
+      let first = try StructDeclSyntax.firstParsed(from: source)
+      let firstFromInitializer = try StructDeclSyntax(firstParsedFrom: source)
+      let only = try StructDeclSyntax.onlyParsed(from: source)
+      let onlyFromInitializer = try StructDeclSyntax(onlyParsedFrom: source)
+      
+      #expect(first.description == firstFromInitializer.description)
+      #expect(first.description == only.description)
+      #expect(only.description == onlyFromInitializer.description)
+    }
+  )
+  
+  try assertSourceParsingProperty(
+    "expression",
+    source: "let flag = true",
+    validate: { source in
+      let first = try BooleanLiteralExprSyntax.firstParsed(from: source)
+      let firstFromInitializer = try BooleanLiteralExprSyntax(firstParsedFrom: source)
+      let only = try BooleanLiteralExprSyntax.onlyParsed(from: source)
+      let onlyFromInitializer = try BooleanLiteralExprSyntax(onlyParsedFrom: source)
+      
+      #expect(first.description == firstFromInitializer.description)
+      #expect(first.description == only.description)
+      #expect(only.description == onlyFromInitializer.description)
+    }
+  )
+  
+  try assertSourceParsingProperty(
+    "pattern",
+    source: "let value = 1",
+    validate: { source in
+      let first = try IdentifierPatternSyntax.firstParsed(from: source)
+      let firstFromInitializer = try IdentifierPatternSyntax(firstParsedFrom: source)
+      let only = try IdentifierPatternSyntax.onlyParsed(from: source)
+      let onlyFromInitializer = try IdentifierPatternSyntax(onlyParsedFrom: source)
+      
+      #expect(first.description == firstFromInitializer.description)
+      #expect(first.description == only.description)
+      #expect(only.description == onlyFromInitializer.description)
+    }
+  )
+  
+  try assertSourceParsingProperty(
+    "statement",
+    source: "func value() -> Int { return 1 }",
+    validate: { source in
+      let first = try ReturnStmtSyntax.firstParsed(from: source)
+      let firstFromInitializer = try ReturnStmtSyntax(firstParsedFrom: source)
+      let only = try ReturnStmtSyntax.onlyParsed(from: source)
+      let onlyFromInitializer = try ReturnStmtSyntax(onlyParsedFrom: source)
+      
+      #expect(first.description == firstFromInitializer.description)
+      #expect(first.description == only.description)
+      #expect(only.description == onlyFromInitializer.description)
+    }
+  )
+  
+  try assertSourceParsingProperty(
+    "type",
+    source: "let value: Int = 1",
+    validate: { source in
+      let first = try IdentifierTypeSyntax.firstParsed(from: source)
+      let firstFromInitializer = try IdentifierTypeSyntax(firstParsedFrom: source)
+      let only = try IdentifierTypeSyntax.onlyParsed(from: source)
+      let onlyFromInitializer = try IdentifierTypeSyntax(onlyParsedFrom: source)
+      
+      #expect(first.description == firstFromInitializer.description)
+      #expect(first.description == only.description)
+      #expect(only.description == onlyFromInitializer.description)
+    }
+  )
+  
+  expectMacroExpansionFailure {
+    _ = try EnumDeclSyntax.firstParsed(from: "struct Example {}")
+  }
+  
+  expectMacroExpansionFailure {
+    _ = try VariableDeclSyntax.onlyParsed(
+      from: """
+      let first = 1
+      let second = 2
+      """
+    )
+  }
+}
+
+@Test("Syntax type-erasure conveniences cover major syntax categories")
+func testSyntaxTypeErasureConveniencesCoverMajorSyntaxCategories() throws {
+  // Hand-written examples: each major syntax protocol family gets erased to
+  // its matching wrapper and then validated, proving the convenience names map
+  // to the intended SwiftSyntax erasure type.
+  let declaration = try StructDeclSyntax.onlyParsed(from: "struct Example {}")
+  let expression = try BooleanLiteralExprSyntax.firstParsed(from: "let flag = true")
+  let pattern = try IdentifierPatternSyntax.firstParsed(from: "let value = 1")
+  let statement = try ReturnStmtSyntax.firstParsed(
+    from: "func value() -> Int { return 1 }"
+  )
+  let type = IdentifierTypeSyntax.forType(named: "Int")
+  
+  #expect(try declaration.eraseToValidatedDeclSyntax().asStructDeclSyntax != nil)
+  #expect(try expression.eraseToValidatedExprSyntax().asBooleanLiteralExprSyntax != nil)
+  #expect(try pattern.eraseToValidatedPatternSyntax().asIdentifierPatternSyntax != nil)
+  #expect(try statement.eraseToValidatedStmtSyntax().asReturnStmtSyntax != nil)
+  #expect(try type.eraseToValidatedTypeSyntax().asIdentifierTypeSyntax != nil)
+  #expect(try type.eraseToValidatedSyntax().asIdentifierTypeSyntax != nil)
+}
+
+@Test("Syntax type-erasure conveniences preserve syntax text")
+func testSyntaxTypeErasureConveniencesPreserveSyntaxText() throws {
+  // Property-style test: across the major syntax protocol families, plain and
+  // validating erasure must preserve the original syntax text. This catches
+  // accidental cross-family erasure while checking more examples than the
+  // focused hand-written test above.
+  let declaration = try StructDeclSyntax.onlyParsed(from: "struct Example {}")
+  let expression = try BooleanLiteralExprSyntax.firstParsed(from: "let flag = true")
+  let pattern = try IdentifierPatternSyntax.firstParsed(from: "let value = 1")
+  let statement = try ReturnStmtSyntax.firstParsed(
+    from: "func value() -> Int { return 1 }"
+  )
+  let type = IdentifierTypeSyntax.forType(named: "Int")
+  
+  #expect(declaration.eraseToDeclSyntax().description == declaration.description)
+  #expect(try declaration.eraseToValidatedDeclSyntax().description == declaration.description)
+  
+  #expect(expression.eraseToExprSyntax().description == expression.description)
+  #expect(try expression.eraseToValidatedExprSyntax().description == expression.description)
+  
+  #expect(pattern.eraseToPatternSyntax().description == pattern.description)
+  #expect(try pattern.eraseToValidatedPatternSyntax().description == pattern.description)
+  
+  #expect(statement.eraseToStmtSyntax().description == statement.description)
+  #expect(try statement.eraseToValidatedStmtSyntax().description == statement.description)
+  
+  #expect(type.eraseToTypeSyntax().description == type.description)
+  #expect(try type.eraseToValidatedTypeSyntax().description == type.description)
+  #expect(type.eraseToSyntax().description == type.description)
+  #expect(try type.eraseToValidatedSyntax().description == type.description)
+}
+
+private func assertTreeSearchProperty<T>(
+  _ sourceFile: SourceFileSyntax,
+  _ type: T.Type
+) where T: SyntaxProtocol {
+  let allMatches = sourceFile.allSyntaxElements(ofType: type)
+  
+  #expect(
+    sourceFile.firstSyntaxElement(ofType: type)?.description
+    ==
+    allMatches.first?.description
+  )
+  #expect(allMatches.allSatisfy { Syntax($0).is(type) })
+}
+
+private func assertSourceParsingProperty(
+  _ name: String,
+  source: String,
+  validate: (String) throws -> Void
+) throws {
+  _ = name
+  try validate(source)
+}
+
+private func expectMacroExpansionFailure(
+  _ operation: () throws -> Void
+) {
+  do {
+    try operation()
+    Issue.record("Expected MacroExpansionFailure")
+  } catch {
+    #expect(error is MacroExpansionFailure)
+  }
+}

--- a/Tests/MacroToolboxTests/Support/SyntaxProtocolElementCastGeneratedPropertyTests.swift
+++ b/Tests/MacroToolboxTests/Support/SyntaxProtocolElementCastGeneratedPropertyTests.swift
@@ -1,0 +1,1778 @@
+import SwiftSyntax
+import Testing
+@testable import MacroToolbox
+
+private struct SyntaxCastConvenienceProbe: Sendable, CustomStringConvertible {
+  let name: String
+  let expectedMatch: @Sendable (Syntax) -> Bool
+  let convenienceIsMatch: @Sendable (Syntax) -> Bool
+  let convenienceAsMatch: @Sendable (Syntax) -> Bool
+
+  var description: String {
+    name
+  }
+}
+
+private struct SyntaxCastSample: CustomStringConvertible {
+  let name: String
+  let syntax: Syntax
+
+  var description: String {
+    name
+  }
+}
+
+private let syntaxCastConvenienceProbes: [SyntaxCastConvenienceProbe] = [
+  SyntaxCastConvenienceProbe(
+    name: "ABIAttributeArgumentsSyntax",
+    expectedMatch: { $0.is(ABIAttributeArgumentsSyntax.self) },
+    convenienceIsMatch: { $0.isABIAttributeArgumentsSyntax },
+    convenienceAsMatch: { $0.asABIAttributeArgumentsSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "AccessorBlockSyntax",
+    expectedMatch: { $0.is(AccessorBlockSyntax.self) },
+    convenienceIsMatch: { $0.isAccessorBlockSyntax },
+    convenienceAsMatch: { $0.asAccessorBlockSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "AccessorDeclListSyntax",
+    expectedMatch: { $0.is(AccessorDeclListSyntax.self) },
+    convenienceIsMatch: { $0.isAccessorDeclListSyntax },
+    convenienceAsMatch: { $0.asAccessorDeclListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "AccessorDeclSyntax",
+    expectedMatch: { $0.is(AccessorDeclSyntax.self) },
+    convenienceIsMatch: { $0.isAccessorDeclSyntax },
+    convenienceAsMatch: { $0.asAccessorDeclSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "AccessorEffectSpecifiersSyntax",
+    expectedMatch: { $0.is(AccessorEffectSpecifiersSyntax.self) },
+    convenienceIsMatch: { $0.isAccessorEffectSpecifiersSyntax },
+    convenienceAsMatch: { $0.asAccessorEffectSpecifiersSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "AccessorParametersSyntax",
+    expectedMatch: { $0.is(AccessorParametersSyntax.self) },
+    convenienceIsMatch: { $0.isAccessorParametersSyntax },
+    convenienceAsMatch: { $0.asAccessorParametersSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ActorDeclSyntax",
+    expectedMatch: { $0.is(ActorDeclSyntax.self) },
+    convenienceIsMatch: { $0.isActorDeclSyntax },
+    convenienceAsMatch: { $0.asActorDeclSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ArrayElementListSyntax",
+    expectedMatch: { $0.is(ArrayElementListSyntax.self) },
+    convenienceIsMatch: { $0.isArrayElementListSyntax },
+    convenienceAsMatch: { $0.asArrayElementListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ArrayElementSyntax",
+    expectedMatch: { $0.is(ArrayElementSyntax.self) },
+    convenienceIsMatch: { $0.isArrayElementSyntax },
+    convenienceAsMatch: { $0.asArrayElementSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ArrayExprSyntax",
+    expectedMatch: { $0.is(ArrayExprSyntax.self) },
+    convenienceIsMatch: { $0.isArrayExprSyntax },
+    convenienceAsMatch: { $0.asArrayExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ArrayTypeSyntax",
+    expectedMatch: { $0.is(ArrayTypeSyntax.self) },
+    convenienceIsMatch: { $0.isArrayTypeSyntax },
+    convenienceAsMatch: { $0.asArrayTypeSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ArrowExprSyntax",
+    expectedMatch: { $0.is(ArrowExprSyntax.self) },
+    convenienceIsMatch: { $0.isArrowExprSyntax },
+    convenienceAsMatch: { $0.asArrowExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "AsExprSyntax",
+    expectedMatch: { $0.is(AsExprSyntax.self) },
+    convenienceIsMatch: { $0.isAsExprSyntax },
+    convenienceAsMatch: { $0.asAsExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "AssignmentExprSyntax",
+    expectedMatch: { $0.is(AssignmentExprSyntax.self) },
+    convenienceIsMatch: { $0.isAssignmentExprSyntax },
+    convenienceAsMatch: { $0.asAssignmentExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "AssociatedTypeDeclSyntax",
+    expectedMatch: { $0.is(AssociatedTypeDeclSyntax.self) },
+    convenienceIsMatch: { $0.isAssociatedTypeDeclSyntax },
+    convenienceAsMatch: { $0.asAssociatedTypeDeclSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "AttributeListSyntax",
+    expectedMatch: { $0.is(AttributeListSyntax.self) },
+    convenienceIsMatch: { $0.isAttributeListSyntax },
+    convenienceAsMatch: { $0.asAttributeListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "AttributeSyntax",
+    expectedMatch: { $0.is(AttributeSyntax.self) },
+    convenienceIsMatch: { $0.isAttributeSyntax },
+    convenienceAsMatch: { $0.asAttributeSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "AttributedTypeSyntax",
+    expectedMatch: { $0.is(AttributedTypeSyntax.self) },
+    convenienceIsMatch: { $0.isAttributedTypeSyntax },
+    convenienceAsMatch: { $0.asAttributedTypeSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "AvailabilityArgumentListSyntax",
+    expectedMatch: { $0.is(AvailabilityArgumentListSyntax.self) },
+    convenienceIsMatch: { $0.isAvailabilityArgumentListSyntax },
+    convenienceAsMatch: { $0.asAvailabilityArgumentListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "AvailabilityArgumentSyntax",
+    expectedMatch: { $0.is(AvailabilityArgumentSyntax.self) },
+    convenienceIsMatch: { $0.isAvailabilityArgumentSyntax },
+    convenienceAsMatch: { $0.asAvailabilityArgumentSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "AvailabilityConditionSyntax",
+    expectedMatch: { $0.is(AvailabilityConditionSyntax.self) },
+    convenienceIsMatch: { $0.isAvailabilityConditionSyntax },
+    convenienceAsMatch: { $0.asAvailabilityConditionSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "AvailabilityLabeledArgumentSyntax",
+    expectedMatch: { $0.is(AvailabilityLabeledArgumentSyntax.self) },
+    convenienceIsMatch: { $0.isAvailabilityLabeledArgumentSyntax },
+    convenienceAsMatch: { $0.asAvailabilityLabeledArgumentSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "AwaitExprSyntax",
+    expectedMatch: { $0.is(AwaitExprSyntax.self) },
+    convenienceIsMatch: { $0.isAwaitExprSyntax },
+    convenienceAsMatch: { $0.asAwaitExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "BackDeployedAttributeArgumentsSyntax",
+    expectedMatch: { $0.is(BackDeployedAttributeArgumentsSyntax.self) },
+    convenienceIsMatch: { $0.isBackDeployedAttributeArgumentsSyntax },
+    convenienceAsMatch: { $0.asBackDeployedAttributeArgumentsSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "BinaryOperatorExprSyntax",
+    expectedMatch: { $0.is(BinaryOperatorExprSyntax.self) },
+    convenienceIsMatch: { $0.isBinaryOperatorExprSyntax },
+    convenienceAsMatch: { $0.asBinaryOperatorExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "BooleanLiteralExprSyntax",
+    expectedMatch: { $0.is(BooleanLiteralExprSyntax.self) },
+    convenienceIsMatch: { $0.isBooleanLiteralExprSyntax },
+    convenienceAsMatch: { $0.asBooleanLiteralExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "BorrowExprSyntax",
+    expectedMatch: { $0.is(BorrowExprSyntax.self) },
+    convenienceIsMatch: { $0.isBorrowExprSyntax },
+    convenienceAsMatch: { $0.asBorrowExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "BreakStmtSyntax",
+    expectedMatch: { $0.is(BreakStmtSyntax.self) },
+    convenienceIsMatch: { $0.isBreakStmtSyntax },
+    convenienceAsMatch: { $0.asBreakStmtSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "CatchClauseListSyntax",
+    expectedMatch: { $0.is(CatchClauseListSyntax.self) },
+    convenienceIsMatch: { $0.isCatchClauseListSyntax },
+    convenienceAsMatch: { $0.asCatchClauseListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "CatchClauseSyntax",
+    expectedMatch: { $0.is(CatchClauseSyntax.self) },
+    convenienceIsMatch: { $0.isCatchClauseSyntax },
+    convenienceAsMatch: { $0.asCatchClauseSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "CatchItemListSyntax",
+    expectedMatch: { $0.is(CatchItemListSyntax.self) },
+    convenienceIsMatch: { $0.isCatchItemListSyntax },
+    convenienceAsMatch: { $0.asCatchItemListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "CatchItemSyntax",
+    expectedMatch: { $0.is(CatchItemSyntax.self) },
+    convenienceIsMatch: { $0.isCatchItemSyntax },
+    convenienceAsMatch: { $0.asCatchItemSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ClassDeclSyntax",
+    expectedMatch: { $0.is(ClassDeclSyntax.self) },
+    convenienceIsMatch: { $0.isClassDeclSyntax },
+    convenienceAsMatch: { $0.asClassDeclSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ClassRestrictionTypeSyntax",
+    expectedMatch: { $0.is(ClassRestrictionTypeSyntax.self) },
+    convenienceIsMatch: { $0.isClassRestrictionTypeSyntax },
+    convenienceAsMatch: { $0.asClassRestrictionTypeSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ClosureCaptureClauseSyntax",
+    expectedMatch: { $0.is(ClosureCaptureClauseSyntax.self) },
+    convenienceIsMatch: { $0.isClosureCaptureClauseSyntax },
+    convenienceAsMatch: { $0.asClosureCaptureClauseSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ClosureCaptureListSyntax",
+    expectedMatch: { $0.is(ClosureCaptureListSyntax.self) },
+    convenienceIsMatch: { $0.isClosureCaptureListSyntax },
+    convenienceAsMatch: { $0.asClosureCaptureListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ClosureCaptureSpecifierSyntax",
+    expectedMatch: { $0.is(ClosureCaptureSpecifierSyntax.self) },
+    convenienceIsMatch: { $0.isClosureCaptureSpecifierSyntax },
+    convenienceAsMatch: { $0.asClosureCaptureSpecifierSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ClosureCaptureSyntax",
+    expectedMatch: { $0.is(ClosureCaptureSyntax.self) },
+    convenienceIsMatch: { $0.isClosureCaptureSyntax },
+    convenienceAsMatch: { $0.asClosureCaptureSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ClosureExprSyntax",
+    expectedMatch: { $0.is(ClosureExprSyntax.self) },
+    convenienceIsMatch: { $0.isClosureExprSyntax },
+    convenienceAsMatch: { $0.asClosureExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ClosureParameterClauseSyntax",
+    expectedMatch: { $0.is(ClosureParameterClauseSyntax.self) },
+    convenienceIsMatch: { $0.isClosureParameterClauseSyntax },
+    convenienceAsMatch: { $0.asClosureParameterClauseSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ClosureParameterListSyntax",
+    expectedMatch: { $0.is(ClosureParameterListSyntax.self) },
+    convenienceIsMatch: { $0.isClosureParameterListSyntax },
+    convenienceAsMatch: { $0.asClosureParameterListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ClosureParameterSyntax",
+    expectedMatch: { $0.is(ClosureParameterSyntax.self) },
+    convenienceIsMatch: { $0.isClosureParameterSyntax },
+    convenienceAsMatch: { $0.asClosureParameterSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ClosureShorthandParameterListSyntax",
+    expectedMatch: { $0.is(ClosureShorthandParameterListSyntax.self) },
+    convenienceIsMatch: { $0.isClosureShorthandParameterListSyntax },
+    convenienceAsMatch: { $0.asClosureShorthandParameterListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ClosureShorthandParameterSyntax",
+    expectedMatch: { $0.is(ClosureShorthandParameterSyntax.self) },
+    convenienceIsMatch: { $0.isClosureShorthandParameterSyntax },
+    convenienceAsMatch: { $0.asClosureShorthandParameterSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ClosureSignatureSyntax",
+    expectedMatch: { $0.is(ClosureSignatureSyntax.self) },
+    convenienceIsMatch: { $0.isClosureSignatureSyntax },
+    convenienceAsMatch: { $0.asClosureSignatureSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "CodeBlockItemListSyntax",
+    expectedMatch: { $0.is(CodeBlockItemListSyntax.self) },
+    convenienceIsMatch: { $0.isCodeBlockItemListSyntax },
+    convenienceAsMatch: { $0.asCodeBlockItemListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "CodeBlockItemSyntax",
+    expectedMatch: { $0.is(CodeBlockItemSyntax.self) },
+    convenienceIsMatch: { $0.isCodeBlockItemSyntax },
+    convenienceAsMatch: { $0.asCodeBlockItemSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "CodeBlockSyntax",
+    expectedMatch: { $0.is(CodeBlockSyntax.self) },
+    convenienceIsMatch: { $0.isCodeBlockSyntax },
+    convenienceAsMatch: { $0.asCodeBlockSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "CompositionTypeElementListSyntax",
+    expectedMatch: { $0.is(CompositionTypeElementListSyntax.self) },
+    convenienceIsMatch: { $0.isCompositionTypeElementListSyntax },
+    convenienceAsMatch: { $0.asCompositionTypeElementListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "CompositionTypeElementSyntax",
+    expectedMatch: { $0.is(CompositionTypeElementSyntax.self) },
+    convenienceIsMatch: { $0.isCompositionTypeElementSyntax },
+    convenienceAsMatch: { $0.asCompositionTypeElementSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "CompositionTypeSyntax",
+    expectedMatch: { $0.is(CompositionTypeSyntax.self) },
+    convenienceIsMatch: { $0.isCompositionTypeSyntax },
+    convenienceAsMatch: { $0.asCompositionTypeSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ConditionElementListSyntax",
+    expectedMatch: { $0.is(ConditionElementListSyntax.self) },
+    convenienceIsMatch: { $0.isConditionElementListSyntax },
+    convenienceAsMatch: { $0.asConditionElementListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ConditionElementSyntax",
+    expectedMatch: { $0.is(ConditionElementSyntax.self) },
+    convenienceIsMatch: { $0.isConditionElementSyntax },
+    convenienceAsMatch: { $0.asConditionElementSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ConformanceRequirementSyntax",
+    expectedMatch: { $0.is(ConformanceRequirementSyntax.self) },
+    convenienceIsMatch: { $0.isConformanceRequirementSyntax },
+    convenienceAsMatch: { $0.asConformanceRequirementSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ConsumeExprSyntax",
+    expectedMatch: { $0.is(ConsumeExprSyntax.self) },
+    convenienceIsMatch: { $0.isConsumeExprSyntax },
+    convenienceAsMatch: { $0.asConsumeExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ContinueStmtSyntax",
+    expectedMatch: { $0.is(ContinueStmtSyntax.self) },
+    convenienceIsMatch: { $0.isContinueStmtSyntax },
+    convenienceAsMatch: { $0.asContinueStmtSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "CopyExprSyntax",
+    expectedMatch: { $0.is(CopyExprSyntax.self) },
+    convenienceIsMatch: { $0.isCopyExprSyntax },
+    convenienceAsMatch: { $0.asCopyExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "DeclModifierDetailSyntax",
+    expectedMatch: { $0.is(DeclModifierDetailSyntax.self) },
+    convenienceIsMatch: { $0.isDeclModifierDetailSyntax },
+    convenienceAsMatch: { $0.asDeclModifierDetailSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "DeclModifierListSyntax",
+    expectedMatch: { $0.is(DeclModifierListSyntax.self) },
+    convenienceIsMatch: { $0.isDeclModifierListSyntax },
+    convenienceAsMatch: { $0.asDeclModifierListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "DeclModifierSyntax",
+    expectedMatch: { $0.is(DeclModifierSyntax.self) },
+    convenienceIsMatch: { $0.isDeclModifierSyntax },
+    convenienceAsMatch: { $0.asDeclModifierSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "DeclNameArgumentListSyntax",
+    expectedMatch: { $0.is(DeclNameArgumentListSyntax.self) },
+    convenienceIsMatch: { $0.isDeclNameArgumentListSyntax },
+    convenienceAsMatch: { $0.asDeclNameArgumentListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "DeclNameArgumentSyntax",
+    expectedMatch: { $0.is(DeclNameArgumentSyntax.self) },
+    convenienceIsMatch: { $0.isDeclNameArgumentSyntax },
+    convenienceAsMatch: { $0.asDeclNameArgumentSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "DeclNameArgumentsSyntax",
+    expectedMatch: { $0.is(DeclNameArgumentsSyntax.self) },
+    convenienceIsMatch: { $0.isDeclNameArgumentsSyntax },
+    convenienceAsMatch: { $0.asDeclNameArgumentsSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "DeclReferenceExprSyntax",
+    expectedMatch: { $0.is(DeclReferenceExprSyntax.self) },
+    convenienceIsMatch: { $0.isDeclReferenceExprSyntax },
+    convenienceAsMatch: { $0.asDeclReferenceExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "DeclSyntax",
+    expectedMatch: { $0.is(DeclSyntax.self) },
+    convenienceIsMatch: { $0.isDeclSyntax },
+    convenienceAsMatch: { $0.asDeclSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "DeferStmtSyntax",
+    expectedMatch: { $0.is(DeferStmtSyntax.self) },
+    convenienceIsMatch: { $0.isDeferStmtSyntax },
+    convenienceAsMatch: { $0.asDeferStmtSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "DeinitializerDeclSyntax",
+    expectedMatch: { $0.is(DeinitializerDeclSyntax.self) },
+    convenienceIsMatch: { $0.isDeinitializerDeclSyntax },
+    convenienceAsMatch: { $0.asDeinitializerDeclSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "DeinitializerEffectSpecifiersSyntax",
+    expectedMatch: { $0.is(DeinitializerEffectSpecifiersSyntax.self) },
+    convenienceIsMatch: { $0.isDeinitializerEffectSpecifiersSyntax },
+    convenienceAsMatch: { $0.asDeinitializerEffectSpecifiersSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "DerivativeAttributeArgumentsSyntax",
+    expectedMatch: { $0.is(DerivativeAttributeArgumentsSyntax.self) },
+    convenienceIsMatch: { $0.isDerivativeAttributeArgumentsSyntax },
+    convenienceAsMatch: { $0.asDerivativeAttributeArgumentsSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "DesignatedTypeListSyntax",
+    expectedMatch: { $0.is(DesignatedTypeListSyntax.self) },
+    convenienceIsMatch: { $0.isDesignatedTypeListSyntax },
+    convenienceAsMatch: { $0.asDesignatedTypeListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "DesignatedTypeSyntax",
+    expectedMatch: { $0.is(DesignatedTypeSyntax.self) },
+    convenienceIsMatch: { $0.isDesignatedTypeSyntax },
+    convenienceAsMatch: { $0.asDesignatedTypeSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "DictionaryElementListSyntax",
+    expectedMatch: { $0.is(DictionaryElementListSyntax.self) },
+    convenienceIsMatch: { $0.isDictionaryElementListSyntax },
+    convenienceAsMatch: { $0.asDictionaryElementListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "DictionaryElementSyntax",
+    expectedMatch: { $0.is(DictionaryElementSyntax.self) },
+    convenienceIsMatch: { $0.isDictionaryElementSyntax },
+    convenienceAsMatch: { $0.asDictionaryElementSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "DictionaryExprSyntax",
+    expectedMatch: { $0.is(DictionaryExprSyntax.self) },
+    convenienceIsMatch: { $0.isDictionaryExprSyntax },
+    convenienceAsMatch: { $0.asDictionaryExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "DictionaryTypeSyntax",
+    expectedMatch: { $0.is(DictionaryTypeSyntax.self) },
+    convenienceIsMatch: { $0.isDictionaryTypeSyntax },
+    convenienceAsMatch: { $0.asDictionaryTypeSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "DifferentiabilityArgumentListSyntax",
+    expectedMatch: { $0.is(DifferentiabilityArgumentListSyntax.self) },
+    convenienceIsMatch: { $0.isDifferentiabilityArgumentListSyntax },
+    convenienceAsMatch: { $0.asDifferentiabilityArgumentListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "DifferentiabilityArgumentSyntax",
+    expectedMatch: { $0.is(DifferentiabilityArgumentSyntax.self) },
+    convenienceIsMatch: { $0.isDifferentiabilityArgumentSyntax },
+    convenienceAsMatch: { $0.asDifferentiabilityArgumentSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "DifferentiabilityArgumentsSyntax",
+    expectedMatch: { $0.is(DifferentiabilityArgumentsSyntax.self) },
+    convenienceIsMatch: { $0.isDifferentiabilityArgumentsSyntax },
+    convenienceAsMatch: { $0.asDifferentiabilityArgumentsSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "DifferentiabilityWithRespectToArgumentSyntax",
+    expectedMatch: { $0.is(DifferentiabilityWithRespectToArgumentSyntax.self) },
+    convenienceIsMatch: { $0.isDifferentiabilityWithRespectToArgumentSyntax },
+    convenienceAsMatch: { $0.asDifferentiabilityWithRespectToArgumentSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "DifferentiableAttributeArgumentsSyntax",
+    expectedMatch: { $0.is(DifferentiableAttributeArgumentsSyntax.self) },
+    convenienceIsMatch: { $0.isDifferentiableAttributeArgumentsSyntax },
+    convenienceAsMatch: { $0.asDifferentiableAttributeArgumentsSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "DiscardAssignmentExprSyntax",
+    expectedMatch: { $0.is(DiscardAssignmentExprSyntax.self) },
+    convenienceIsMatch: { $0.isDiscardAssignmentExprSyntax },
+    convenienceAsMatch: { $0.asDiscardAssignmentExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "DiscardStmtSyntax",
+    expectedMatch: { $0.is(DiscardStmtSyntax.self) },
+    convenienceIsMatch: { $0.isDiscardStmtSyntax },
+    convenienceAsMatch: { $0.asDiscardStmtSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "DoStmtSyntax",
+    expectedMatch: { $0.is(DoStmtSyntax.self) },
+    convenienceIsMatch: { $0.isDoStmtSyntax },
+    convenienceAsMatch: { $0.asDoStmtSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "DocumentationAttributeArgumentListSyntax",
+    expectedMatch: { $0.is(DocumentationAttributeArgumentListSyntax.self) },
+    convenienceIsMatch: { $0.isDocumentationAttributeArgumentListSyntax },
+    convenienceAsMatch: { $0.asDocumentationAttributeArgumentListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "DocumentationAttributeArgumentSyntax",
+    expectedMatch: { $0.is(DocumentationAttributeArgumentSyntax.self) },
+    convenienceIsMatch: { $0.isDocumentationAttributeArgumentSyntax },
+    convenienceAsMatch: { $0.asDocumentationAttributeArgumentSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "DynamicReplacementAttributeArgumentsSyntax",
+    expectedMatch: { $0.is(DynamicReplacementAttributeArgumentsSyntax.self) },
+    convenienceIsMatch: { $0.isDynamicReplacementAttributeArgumentsSyntax },
+    convenienceAsMatch: { $0.asDynamicReplacementAttributeArgumentsSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "EditorPlaceholderDeclSyntax",
+    expectedMatch: { $0.is(EditorPlaceholderDeclSyntax.self) },
+    convenienceIsMatch: { $0.isEditorPlaceholderDeclSyntax },
+    convenienceAsMatch: { $0.asEditorPlaceholderDeclSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "EditorPlaceholderExprSyntax",
+    expectedMatch: { $0.is(EditorPlaceholderExprSyntax.self) },
+    convenienceIsMatch: { $0.isEditorPlaceholderExprSyntax },
+    convenienceAsMatch: { $0.asEditorPlaceholderExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "EffectsAttributeArgumentListSyntax",
+    expectedMatch: { $0.is(EffectsAttributeArgumentListSyntax.self) },
+    convenienceIsMatch: { $0.isEffectsAttributeArgumentListSyntax },
+    convenienceAsMatch: { $0.asEffectsAttributeArgumentListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "EnumCaseDeclSyntax",
+    expectedMatch: { $0.is(EnumCaseDeclSyntax.self) },
+    convenienceIsMatch: { $0.isEnumCaseDeclSyntax },
+    convenienceAsMatch: { $0.asEnumCaseDeclSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "EnumCaseElementListSyntax",
+    expectedMatch: { $0.is(EnumCaseElementListSyntax.self) },
+    convenienceIsMatch: { $0.isEnumCaseElementListSyntax },
+    convenienceAsMatch: { $0.asEnumCaseElementListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "EnumCaseElementSyntax",
+    expectedMatch: { $0.is(EnumCaseElementSyntax.self) },
+    convenienceIsMatch: { $0.isEnumCaseElementSyntax },
+    convenienceAsMatch: { $0.asEnumCaseElementSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "EnumCaseParameterClauseSyntax",
+    expectedMatch: { $0.is(EnumCaseParameterClauseSyntax.self) },
+    convenienceIsMatch: { $0.isEnumCaseParameterClauseSyntax },
+    convenienceAsMatch: { $0.asEnumCaseParameterClauseSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "EnumCaseParameterListSyntax",
+    expectedMatch: { $0.is(EnumCaseParameterListSyntax.self) },
+    convenienceIsMatch: { $0.isEnumCaseParameterListSyntax },
+    convenienceAsMatch: { $0.asEnumCaseParameterListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "EnumCaseParameterSyntax",
+    expectedMatch: { $0.is(EnumCaseParameterSyntax.self) },
+    convenienceIsMatch: { $0.isEnumCaseParameterSyntax },
+    convenienceAsMatch: { $0.asEnumCaseParameterSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "EnumDeclSyntax",
+    expectedMatch: { $0.is(EnumDeclSyntax.self) },
+    convenienceIsMatch: { $0.isEnumDeclSyntax },
+    convenienceAsMatch: { $0.asEnumDeclSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ExprListSyntax",
+    expectedMatch: { $0.is(ExprListSyntax.self) },
+    convenienceIsMatch: { $0.isExprListSyntax },
+    convenienceAsMatch: { $0.asExprListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ExprSyntax",
+    expectedMatch: { $0.is(ExprSyntax.self) },
+    convenienceIsMatch: { $0.isExprSyntax },
+    convenienceAsMatch: { $0.asExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ExpressionPatternSyntax",
+    expectedMatch: { $0.is(ExpressionPatternSyntax.self) },
+    convenienceIsMatch: { $0.isExpressionPatternSyntax },
+    convenienceAsMatch: { $0.asExpressionPatternSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ExpressionSegmentSyntax",
+    expectedMatch: { $0.is(ExpressionSegmentSyntax.self) },
+    convenienceIsMatch: { $0.isExpressionSegmentSyntax },
+    convenienceAsMatch: { $0.asExpressionSegmentSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ExpressionStmtSyntax",
+    expectedMatch: { $0.is(ExpressionStmtSyntax.self) },
+    convenienceIsMatch: { $0.isExpressionStmtSyntax },
+    convenienceAsMatch: { $0.asExpressionStmtSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ExtensionDeclSyntax",
+    expectedMatch: { $0.is(ExtensionDeclSyntax.self) },
+    convenienceIsMatch: { $0.isExtensionDeclSyntax },
+    convenienceAsMatch: { $0.asExtensionDeclSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "FallThroughStmtSyntax",
+    expectedMatch: { $0.is(FallThroughStmtSyntax.self) },
+    convenienceIsMatch: { $0.isFallThroughStmtSyntax },
+    convenienceAsMatch: { $0.asFallThroughStmtSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "FloatLiteralExprSyntax",
+    expectedMatch: { $0.is(FloatLiteralExprSyntax.self) },
+    convenienceIsMatch: { $0.isFloatLiteralExprSyntax },
+    convenienceAsMatch: { $0.asFloatLiteralExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ForStmtSyntax",
+    expectedMatch: { $0.is(ForStmtSyntax.self) },
+    convenienceIsMatch: { $0.isForStmtSyntax },
+    convenienceAsMatch: { $0.asForStmtSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ForceUnwrapExprSyntax",
+    expectedMatch: { $0.is(ForceUnwrapExprSyntax.self) },
+    convenienceIsMatch: { $0.isForceUnwrapExprSyntax },
+    convenienceAsMatch: { $0.asForceUnwrapExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "FunctionCallExprSyntax",
+    expectedMatch: { $0.is(FunctionCallExprSyntax.self) },
+    convenienceIsMatch: { $0.isFunctionCallExprSyntax },
+    convenienceAsMatch: { $0.asFunctionCallExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "FunctionDeclSyntax",
+    expectedMatch: { $0.is(FunctionDeclSyntax.self) },
+    convenienceIsMatch: { $0.isFunctionDeclSyntax },
+    convenienceAsMatch: { $0.asFunctionDeclSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "FunctionEffectSpecifiersSyntax",
+    expectedMatch: { $0.is(FunctionEffectSpecifiersSyntax.self) },
+    convenienceIsMatch: { $0.isFunctionEffectSpecifiersSyntax },
+    convenienceAsMatch: { $0.asFunctionEffectSpecifiersSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "FunctionParameterClauseSyntax",
+    expectedMatch: { $0.is(FunctionParameterClauseSyntax.self) },
+    convenienceIsMatch: { $0.isFunctionParameterClauseSyntax },
+    convenienceAsMatch: { $0.asFunctionParameterClauseSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "FunctionParameterListSyntax",
+    expectedMatch: { $0.is(FunctionParameterListSyntax.self) },
+    convenienceIsMatch: { $0.isFunctionParameterListSyntax },
+    convenienceAsMatch: { $0.asFunctionParameterListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "FunctionParameterSyntax",
+    expectedMatch: { $0.is(FunctionParameterSyntax.self) },
+    convenienceIsMatch: { $0.isFunctionParameterSyntax },
+    convenienceAsMatch: { $0.asFunctionParameterSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "FunctionSignatureSyntax",
+    expectedMatch: { $0.is(FunctionSignatureSyntax.self) },
+    convenienceIsMatch: { $0.isFunctionSignatureSyntax },
+    convenienceAsMatch: { $0.asFunctionSignatureSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "FunctionTypeSyntax",
+    expectedMatch: { $0.is(FunctionTypeSyntax.self) },
+    convenienceIsMatch: { $0.isFunctionTypeSyntax },
+    convenienceAsMatch: { $0.asFunctionTypeSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "GenericArgumentClauseSyntax",
+    expectedMatch: { $0.is(GenericArgumentClauseSyntax.self) },
+    convenienceIsMatch: { $0.isGenericArgumentClauseSyntax },
+    convenienceAsMatch: { $0.asGenericArgumentClauseSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "GenericArgumentListSyntax",
+    expectedMatch: { $0.is(GenericArgumentListSyntax.self) },
+    convenienceIsMatch: { $0.isGenericArgumentListSyntax },
+    convenienceAsMatch: { $0.asGenericArgumentListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "GenericArgumentSyntax",
+    expectedMatch: { $0.is(GenericArgumentSyntax.self) },
+    convenienceIsMatch: { $0.isGenericArgumentSyntax },
+    convenienceAsMatch: { $0.asGenericArgumentSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "GenericParameterClauseSyntax",
+    expectedMatch: { $0.is(GenericParameterClauseSyntax.self) },
+    convenienceIsMatch: { $0.isGenericParameterClauseSyntax },
+    convenienceAsMatch: { $0.asGenericParameterClauseSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "GenericParameterListSyntax",
+    expectedMatch: { $0.is(GenericParameterListSyntax.self) },
+    convenienceIsMatch: { $0.isGenericParameterListSyntax },
+    convenienceAsMatch: { $0.asGenericParameterListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "GenericParameterSyntax",
+    expectedMatch: { $0.is(GenericParameterSyntax.self) },
+    convenienceIsMatch: { $0.isGenericParameterSyntax },
+    convenienceAsMatch: { $0.asGenericParameterSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "GenericRequirementListSyntax",
+    expectedMatch: { $0.is(GenericRequirementListSyntax.self) },
+    convenienceIsMatch: { $0.isGenericRequirementListSyntax },
+    convenienceAsMatch: { $0.asGenericRequirementListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "GenericRequirementSyntax",
+    expectedMatch: { $0.is(GenericRequirementSyntax.self) },
+    convenienceIsMatch: { $0.isGenericRequirementSyntax },
+    convenienceAsMatch: { $0.asGenericRequirementSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "GenericSpecializationExprSyntax",
+    expectedMatch: { $0.is(GenericSpecializationExprSyntax.self) },
+    convenienceIsMatch: { $0.isGenericSpecializationExprSyntax },
+    convenienceAsMatch: { $0.asGenericSpecializationExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "GenericWhereClauseSyntax",
+    expectedMatch: { $0.is(GenericWhereClauseSyntax.self) },
+    convenienceIsMatch: { $0.isGenericWhereClauseSyntax },
+    convenienceAsMatch: { $0.asGenericWhereClauseSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "GuardStmtSyntax",
+    expectedMatch: { $0.is(GuardStmtSyntax.self) },
+    convenienceIsMatch: { $0.isGuardStmtSyntax },
+    convenienceAsMatch: { $0.asGuardStmtSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "IdentifierPatternSyntax",
+    expectedMatch: { $0.is(IdentifierPatternSyntax.self) },
+    convenienceIsMatch: { $0.isIdentifierPatternSyntax },
+    convenienceAsMatch: { $0.asIdentifierPatternSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "IdentifierTypeSyntax",
+    expectedMatch: { $0.is(IdentifierTypeSyntax.self) },
+    convenienceIsMatch: { $0.isIdentifierTypeSyntax },
+    convenienceAsMatch: { $0.asIdentifierTypeSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "IfConfigClauseListSyntax",
+    expectedMatch: { $0.is(IfConfigClauseListSyntax.self) },
+    convenienceIsMatch: { $0.isIfConfigClauseListSyntax },
+    convenienceAsMatch: { $0.asIfConfigClauseListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "IfConfigClauseSyntax",
+    expectedMatch: { $0.is(IfConfigClauseSyntax.self) },
+    convenienceIsMatch: { $0.isIfConfigClauseSyntax },
+    convenienceAsMatch: { $0.asIfConfigClauseSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "IfConfigDeclSyntax",
+    expectedMatch: { $0.is(IfConfigDeclSyntax.self) },
+    convenienceIsMatch: { $0.isIfConfigDeclSyntax },
+    convenienceAsMatch: { $0.asIfConfigDeclSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "IfExprSyntax",
+    expectedMatch: { $0.is(IfExprSyntax.self) },
+    convenienceIsMatch: { $0.isIfExprSyntax },
+    convenienceAsMatch: { $0.asIfExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ImplementsAttributeArgumentsSyntax",
+    expectedMatch: { $0.is(ImplementsAttributeArgumentsSyntax.self) },
+    convenienceIsMatch: { $0.isImplementsAttributeArgumentsSyntax },
+    convenienceAsMatch: { $0.asImplementsAttributeArgumentsSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ImplicitlyUnwrappedOptionalTypeSyntax",
+    expectedMatch: { $0.is(ImplicitlyUnwrappedOptionalTypeSyntax.self) },
+    convenienceIsMatch: { $0.isImplicitlyUnwrappedOptionalTypeSyntax },
+    convenienceAsMatch: { $0.asImplicitlyUnwrappedOptionalTypeSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ImportDeclSyntax",
+    expectedMatch: { $0.is(ImportDeclSyntax.self) },
+    convenienceIsMatch: { $0.isImportDeclSyntax },
+    convenienceAsMatch: { $0.asImportDeclSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ImportPathComponentListSyntax",
+    expectedMatch: { $0.is(ImportPathComponentListSyntax.self) },
+    convenienceIsMatch: { $0.isImportPathComponentListSyntax },
+    convenienceAsMatch: { $0.asImportPathComponentListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ImportPathComponentSyntax",
+    expectedMatch: { $0.is(ImportPathComponentSyntax.self) },
+    convenienceIsMatch: { $0.isImportPathComponentSyntax },
+    convenienceAsMatch: { $0.asImportPathComponentSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "InOutExprSyntax",
+    expectedMatch: { $0.is(InOutExprSyntax.self) },
+    convenienceIsMatch: { $0.isInOutExprSyntax },
+    convenienceAsMatch: { $0.asInOutExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "InfixOperatorExprSyntax",
+    expectedMatch: { $0.is(InfixOperatorExprSyntax.self) },
+    convenienceIsMatch: { $0.isInfixOperatorExprSyntax },
+    convenienceAsMatch: { $0.asInfixOperatorExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "InheritanceClauseSyntax",
+    expectedMatch: { $0.is(InheritanceClauseSyntax.self) },
+    convenienceIsMatch: { $0.isInheritanceClauseSyntax },
+    convenienceAsMatch: { $0.asInheritanceClauseSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "InheritedTypeListSyntax",
+    expectedMatch: { $0.is(InheritedTypeListSyntax.self) },
+    convenienceIsMatch: { $0.isInheritedTypeListSyntax },
+    convenienceAsMatch: { $0.asInheritedTypeListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "InheritedTypeSyntax",
+    expectedMatch: { $0.is(InheritedTypeSyntax.self) },
+    convenienceIsMatch: { $0.isInheritedTypeSyntax },
+    convenienceAsMatch: { $0.asInheritedTypeSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "InitializerClauseSyntax",
+    expectedMatch: { $0.is(InitializerClauseSyntax.self) },
+    convenienceIsMatch: { $0.isInitializerClauseSyntax },
+    convenienceAsMatch: { $0.asInitializerClauseSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "InitializerDeclSyntax",
+    expectedMatch: { $0.is(InitializerDeclSyntax.self) },
+    convenienceIsMatch: { $0.isInitializerDeclSyntax },
+    convenienceAsMatch: { $0.asInitializerDeclSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "InlineArrayTypeSyntax",
+    expectedMatch: { $0.is(InlineArrayTypeSyntax.self) },
+    convenienceIsMatch: { $0.isInlineArrayTypeSyntax },
+    convenienceAsMatch: { $0.asInlineArrayTypeSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "IntegerLiteralExprSyntax",
+    expectedMatch: { $0.is(IntegerLiteralExprSyntax.self) },
+    convenienceIsMatch: { $0.isIntegerLiteralExprSyntax },
+    convenienceAsMatch: { $0.asIntegerLiteralExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "IsExprSyntax",
+    expectedMatch: { $0.is(IsExprSyntax.self) },
+    convenienceIsMatch: { $0.isIsExprSyntax },
+    convenienceAsMatch: { $0.asIsExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "IsTypePatternSyntax",
+    expectedMatch: { $0.is(IsTypePatternSyntax.self) },
+    convenienceIsMatch: { $0.isIsTypePatternSyntax },
+    convenienceAsMatch: { $0.asIsTypePatternSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "KeyPathComponentListSyntax",
+    expectedMatch: { $0.is(KeyPathComponentListSyntax.self) },
+    convenienceIsMatch: { $0.isKeyPathComponentListSyntax },
+    convenienceAsMatch: { $0.asKeyPathComponentListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "KeyPathComponentSyntax",
+    expectedMatch: { $0.is(KeyPathComponentSyntax.self) },
+    convenienceIsMatch: { $0.isKeyPathComponentSyntax },
+    convenienceAsMatch: { $0.asKeyPathComponentSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "KeyPathExprSyntax",
+    expectedMatch: { $0.is(KeyPathExprSyntax.self) },
+    convenienceIsMatch: { $0.isKeyPathExprSyntax },
+    convenienceAsMatch: { $0.asKeyPathExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "KeyPathOptionalComponentSyntax",
+    expectedMatch: { $0.is(KeyPathOptionalComponentSyntax.self) },
+    convenienceIsMatch: { $0.isKeyPathOptionalComponentSyntax },
+    convenienceAsMatch: { $0.asKeyPathOptionalComponentSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "KeyPathPropertyComponentSyntax",
+    expectedMatch: { $0.is(KeyPathPropertyComponentSyntax.self) },
+    convenienceIsMatch: { $0.isKeyPathPropertyComponentSyntax },
+    convenienceAsMatch: { $0.asKeyPathPropertyComponentSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "KeyPathSubscriptComponentSyntax",
+    expectedMatch: { $0.is(KeyPathSubscriptComponentSyntax.self) },
+    convenienceIsMatch: { $0.isKeyPathSubscriptComponentSyntax },
+    convenienceAsMatch: { $0.asKeyPathSubscriptComponentSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "LabeledExprListSyntax",
+    expectedMatch: { $0.is(LabeledExprListSyntax.self) },
+    convenienceIsMatch: { $0.isLabeledExprListSyntax },
+    convenienceAsMatch: { $0.asLabeledExprListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "LabeledExprSyntax",
+    expectedMatch: { $0.is(LabeledExprSyntax.self) },
+    convenienceIsMatch: { $0.isLabeledExprSyntax },
+    convenienceAsMatch: { $0.asLabeledExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "LabeledSpecializeArgumentSyntax",
+    expectedMatch: { $0.is(LabeledSpecializeArgumentSyntax.self) },
+    convenienceIsMatch: { $0.isLabeledSpecializeArgumentSyntax },
+    convenienceAsMatch: { $0.asLabeledSpecializeArgumentSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "LabeledStmtSyntax",
+    expectedMatch: { $0.is(LabeledStmtSyntax.self) },
+    convenienceIsMatch: { $0.isLabeledStmtSyntax },
+    convenienceAsMatch: { $0.asLabeledStmtSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "LayoutRequirementSyntax",
+    expectedMatch: { $0.is(LayoutRequirementSyntax.self) },
+    convenienceIsMatch: { $0.isLayoutRequirementSyntax },
+    convenienceAsMatch: { $0.asLayoutRequirementSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "MacroDeclSyntax",
+    expectedMatch: { $0.is(MacroDeclSyntax.self) },
+    convenienceIsMatch: { $0.isMacroDeclSyntax },
+    convenienceAsMatch: { $0.asMacroDeclSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "MacroExpansionDeclSyntax",
+    expectedMatch: { $0.is(MacroExpansionDeclSyntax.self) },
+    convenienceIsMatch: { $0.isMacroExpansionDeclSyntax },
+    convenienceAsMatch: { $0.asMacroExpansionDeclSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "MacroExpansionExprSyntax",
+    expectedMatch: { $0.is(MacroExpansionExprSyntax.self) },
+    convenienceIsMatch: { $0.isMacroExpansionExprSyntax },
+    convenienceAsMatch: { $0.asMacroExpansionExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "MatchingPatternConditionSyntax",
+    expectedMatch: { $0.is(MatchingPatternConditionSyntax.self) },
+    convenienceIsMatch: { $0.isMatchingPatternConditionSyntax },
+    convenienceAsMatch: { $0.asMatchingPatternConditionSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "MemberAccessExprSyntax",
+    expectedMatch: { $0.is(MemberAccessExprSyntax.self) },
+    convenienceIsMatch: { $0.isMemberAccessExprSyntax },
+    convenienceAsMatch: { $0.asMemberAccessExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "MemberBlockItemListSyntax",
+    expectedMatch: { $0.is(MemberBlockItemListSyntax.self) },
+    convenienceIsMatch: { $0.isMemberBlockItemListSyntax },
+    convenienceAsMatch: { $0.asMemberBlockItemListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "MemberBlockItemSyntax",
+    expectedMatch: { $0.is(MemberBlockItemSyntax.self) },
+    convenienceIsMatch: { $0.isMemberBlockItemSyntax },
+    convenienceAsMatch: { $0.asMemberBlockItemSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "MemberBlockSyntax",
+    expectedMatch: { $0.is(MemberBlockSyntax.self) },
+    convenienceIsMatch: { $0.isMemberBlockSyntax },
+    convenienceAsMatch: { $0.asMemberBlockSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "MemberTypeSyntax",
+    expectedMatch: { $0.is(MemberTypeSyntax.self) },
+    convenienceIsMatch: { $0.isMemberTypeSyntax },
+    convenienceAsMatch: { $0.asMemberTypeSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "MetatypeTypeSyntax",
+    expectedMatch: { $0.is(MetatypeTypeSyntax.self) },
+    convenienceIsMatch: { $0.isMetatypeTypeSyntax },
+    convenienceAsMatch: { $0.asMetatypeTypeSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "MissingDeclSyntax",
+    expectedMatch: { $0.is(MissingDeclSyntax.self) },
+    convenienceIsMatch: { $0.isMissingDeclSyntax },
+    convenienceAsMatch: { $0.asMissingDeclSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "MissingExprSyntax",
+    expectedMatch: { $0.is(MissingExprSyntax.self) },
+    convenienceIsMatch: { $0.isMissingExprSyntax },
+    convenienceAsMatch: { $0.asMissingExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "MissingPatternSyntax",
+    expectedMatch: { $0.is(MissingPatternSyntax.self) },
+    convenienceIsMatch: { $0.isMissingPatternSyntax },
+    convenienceAsMatch: { $0.asMissingPatternSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "MissingStmtSyntax",
+    expectedMatch: { $0.is(MissingStmtSyntax.self) },
+    convenienceIsMatch: { $0.isMissingStmtSyntax },
+    convenienceAsMatch: { $0.asMissingStmtSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "MissingSyntax",
+    expectedMatch: { $0.is(MissingSyntax.self) },
+    convenienceIsMatch: { $0.isMissingSyntax },
+    convenienceAsMatch: { $0.asMissingSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "MissingTypeSyntax",
+    expectedMatch: { $0.is(MissingTypeSyntax.self) },
+    convenienceIsMatch: { $0.isMissingTypeSyntax },
+    convenienceAsMatch: { $0.asMissingTypeSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "MultipleTrailingClosureElementListSyntax",
+    expectedMatch: { $0.is(MultipleTrailingClosureElementListSyntax.self) },
+    convenienceIsMatch: { $0.isMultipleTrailingClosureElementListSyntax },
+    convenienceAsMatch: { $0.asMultipleTrailingClosureElementListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "MultipleTrailingClosureElementSyntax",
+    expectedMatch: { $0.is(MultipleTrailingClosureElementSyntax.self) },
+    convenienceIsMatch: { $0.isMultipleTrailingClosureElementSyntax },
+    convenienceAsMatch: { $0.asMultipleTrailingClosureElementSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "NamedOpaqueReturnTypeSyntax",
+    expectedMatch: { $0.is(NamedOpaqueReturnTypeSyntax.self) },
+    convenienceIsMatch: { $0.isNamedOpaqueReturnTypeSyntax },
+    convenienceAsMatch: { $0.asNamedOpaqueReturnTypeSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "NilLiteralExprSyntax",
+    expectedMatch: { $0.is(NilLiteralExprSyntax.self) },
+    convenienceIsMatch: { $0.isNilLiteralExprSyntax },
+    convenienceAsMatch: { $0.asNilLiteralExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "NonisolatedSpecifierArgumentSyntax",
+    expectedMatch: { $0.is(NonisolatedSpecifierArgumentSyntax.self) },
+    convenienceIsMatch: { $0.isNonisolatedSpecifierArgumentSyntax },
+    convenienceAsMatch: { $0.asNonisolatedSpecifierArgumentSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "NonisolatedTypeSpecifierSyntax",
+    expectedMatch: { $0.is(NonisolatedTypeSpecifierSyntax.self) },
+    convenienceIsMatch: { $0.isNonisolatedTypeSpecifierSyntax },
+    convenienceAsMatch: { $0.asNonisolatedTypeSpecifierSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ObjCSelectorPieceListSyntax",
+    expectedMatch: { $0.is(ObjCSelectorPieceListSyntax.self) },
+    convenienceIsMatch: { $0.isObjCSelectorPieceListSyntax },
+    convenienceAsMatch: { $0.asObjCSelectorPieceListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ObjCSelectorPieceSyntax",
+    expectedMatch: { $0.is(ObjCSelectorPieceSyntax.self) },
+    convenienceIsMatch: { $0.isObjCSelectorPieceSyntax },
+    convenienceAsMatch: { $0.asObjCSelectorPieceSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "OperatorDeclSyntax",
+    expectedMatch: { $0.is(OperatorDeclSyntax.self) },
+    convenienceIsMatch: { $0.isOperatorDeclSyntax },
+    convenienceAsMatch: { $0.asOperatorDeclSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "OperatorPrecedenceAndTypesSyntax",
+    expectedMatch: { $0.is(OperatorPrecedenceAndTypesSyntax.self) },
+    convenienceIsMatch: { $0.isOperatorPrecedenceAndTypesSyntax },
+    convenienceAsMatch: { $0.asOperatorPrecedenceAndTypesSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "OptionalBindingConditionSyntax",
+    expectedMatch: { $0.is(OptionalBindingConditionSyntax.self) },
+    convenienceIsMatch: { $0.isOptionalBindingConditionSyntax },
+    convenienceAsMatch: { $0.asOptionalBindingConditionSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "OptionalChainingExprSyntax",
+    expectedMatch: { $0.is(OptionalChainingExprSyntax.self) },
+    convenienceIsMatch: { $0.isOptionalChainingExprSyntax },
+    convenienceAsMatch: { $0.asOptionalChainingExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "OptionalTypeSyntax",
+    expectedMatch: { $0.is(OptionalTypeSyntax.self) },
+    convenienceIsMatch: { $0.isOptionalTypeSyntax },
+    convenienceAsMatch: { $0.asOptionalTypeSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "OriginallyDefinedInAttributeArgumentsSyntax",
+    expectedMatch: { $0.is(OriginallyDefinedInAttributeArgumentsSyntax.self) },
+    convenienceIsMatch: { $0.isOriginallyDefinedInAttributeArgumentsSyntax },
+    convenienceAsMatch: { $0.asOriginallyDefinedInAttributeArgumentsSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "PackElementExprSyntax",
+    expectedMatch: { $0.is(PackElementExprSyntax.self) },
+    convenienceIsMatch: { $0.isPackElementExprSyntax },
+    convenienceAsMatch: { $0.asPackElementExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "PackElementTypeSyntax",
+    expectedMatch: { $0.is(PackElementTypeSyntax.self) },
+    convenienceIsMatch: { $0.isPackElementTypeSyntax },
+    convenienceAsMatch: { $0.asPackElementTypeSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "PackExpansionExprSyntax",
+    expectedMatch: { $0.is(PackExpansionExprSyntax.self) },
+    convenienceIsMatch: { $0.isPackExpansionExprSyntax },
+    convenienceAsMatch: { $0.asPackExpansionExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "PackExpansionTypeSyntax",
+    expectedMatch: { $0.is(PackExpansionTypeSyntax.self) },
+    convenienceIsMatch: { $0.isPackExpansionTypeSyntax },
+    convenienceAsMatch: { $0.asPackExpansionTypeSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "PatternBindingListSyntax",
+    expectedMatch: { $0.is(PatternBindingListSyntax.self) },
+    convenienceIsMatch: { $0.isPatternBindingListSyntax },
+    convenienceAsMatch: { $0.asPatternBindingListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "PatternBindingSyntax",
+    expectedMatch: { $0.is(PatternBindingSyntax.self) },
+    convenienceIsMatch: { $0.isPatternBindingSyntax },
+    convenienceAsMatch: { $0.asPatternBindingSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "PatternExprSyntax",
+    expectedMatch: { $0.is(PatternExprSyntax.self) },
+    convenienceIsMatch: { $0.isPatternExprSyntax },
+    convenienceAsMatch: { $0.asPatternExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "PatternSyntax",
+    expectedMatch: { $0.is(PatternSyntax.self) },
+    convenienceIsMatch: { $0.isPatternSyntax },
+    convenienceAsMatch: { $0.asPatternSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "PlatformVersionItemListSyntax",
+    expectedMatch: { $0.is(PlatformVersionItemListSyntax.self) },
+    convenienceIsMatch: { $0.isPlatformVersionItemListSyntax },
+    convenienceAsMatch: { $0.asPlatformVersionItemListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "PlatformVersionItemSyntax",
+    expectedMatch: { $0.is(PlatformVersionItemSyntax.self) },
+    convenienceIsMatch: { $0.isPlatformVersionItemSyntax },
+    convenienceAsMatch: { $0.asPlatformVersionItemSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "PlatformVersionSyntax",
+    expectedMatch: { $0.is(PlatformVersionSyntax.self) },
+    convenienceIsMatch: { $0.isPlatformVersionSyntax },
+    convenienceAsMatch: { $0.asPlatformVersionSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "PostfixIfConfigExprSyntax",
+    expectedMatch: { $0.is(PostfixIfConfigExprSyntax.self) },
+    convenienceIsMatch: { $0.isPostfixIfConfigExprSyntax },
+    convenienceAsMatch: { $0.asPostfixIfConfigExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "PostfixOperatorExprSyntax",
+    expectedMatch: { $0.is(PostfixOperatorExprSyntax.self) },
+    convenienceIsMatch: { $0.isPostfixOperatorExprSyntax },
+    convenienceAsMatch: { $0.asPostfixOperatorExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "PoundSourceLocationArgumentsSyntax",
+    expectedMatch: { $0.is(PoundSourceLocationArgumentsSyntax.self) },
+    convenienceIsMatch: { $0.isPoundSourceLocationArgumentsSyntax },
+    convenienceAsMatch: { $0.asPoundSourceLocationArgumentsSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "PoundSourceLocationSyntax",
+    expectedMatch: { $0.is(PoundSourceLocationSyntax.self) },
+    convenienceIsMatch: { $0.isPoundSourceLocationSyntax },
+    convenienceAsMatch: { $0.asPoundSourceLocationSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "PrecedenceGroupAssignmentSyntax",
+    expectedMatch: { $0.is(PrecedenceGroupAssignmentSyntax.self) },
+    convenienceIsMatch: { $0.isPrecedenceGroupAssignmentSyntax },
+    convenienceAsMatch: { $0.asPrecedenceGroupAssignmentSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "PrecedenceGroupAssociativitySyntax",
+    expectedMatch: { $0.is(PrecedenceGroupAssociativitySyntax.self) },
+    convenienceIsMatch: { $0.isPrecedenceGroupAssociativitySyntax },
+    convenienceAsMatch: { $0.asPrecedenceGroupAssociativitySyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "PrecedenceGroupAttributeListSyntax",
+    expectedMatch: { $0.is(PrecedenceGroupAttributeListSyntax.self) },
+    convenienceIsMatch: { $0.isPrecedenceGroupAttributeListSyntax },
+    convenienceAsMatch: { $0.asPrecedenceGroupAttributeListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "PrecedenceGroupDeclSyntax",
+    expectedMatch: { $0.is(PrecedenceGroupDeclSyntax.self) },
+    convenienceIsMatch: { $0.isPrecedenceGroupDeclSyntax },
+    convenienceAsMatch: { $0.asPrecedenceGroupDeclSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "PrecedenceGroupNameListSyntax",
+    expectedMatch: { $0.is(PrecedenceGroupNameListSyntax.self) },
+    convenienceIsMatch: { $0.isPrecedenceGroupNameListSyntax },
+    convenienceAsMatch: { $0.asPrecedenceGroupNameListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "PrecedenceGroupNameSyntax",
+    expectedMatch: { $0.is(PrecedenceGroupNameSyntax.self) },
+    convenienceIsMatch: { $0.isPrecedenceGroupNameSyntax },
+    convenienceAsMatch: { $0.asPrecedenceGroupNameSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "PrecedenceGroupRelationSyntax",
+    expectedMatch: { $0.is(PrecedenceGroupRelationSyntax.self) },
+    convenienceIsMatch: { $0.isPrecedenceGroupRelationSyntax },
+    convenienceAsMatch: { $0.asPrecedenceGroupRelationSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "PrefixOperatorExprSyntax",
+    expectedMatch: { $0.is(PrefixOperatorExprSyntax.self) },
+    convenienceIsMatch: { $0.isPrefixOperatorExprSyntax },
+    convenienceAsMatch: { $0.asPrefixOperatorExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "PrimaryAssociatedTypeClauseSyntax",
+    expectedMatch: { $0.is(PrimaryAssociatedTypeClauseSyntax.self) },
+    convenienceIsMatch: { $0.isPrimaryAssociatedTypeClauseSyntax },
+    convenienceAsMatch: { $0.asPrimaryAssociatedTypeClauseSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "PrimaryAssociatedTypeListSyntax",
+    expectedMatch: { $0.is(PrimaryAssociatedTypeListSyntax.self) },
+    convenienceIsMatch: { $0.isPrimaryAssociatedTypeListSyntax },
+    convenienceAsMatch: { $0.asPrimaryAssociatedTypeListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "PrimaryAssociatedTypeSyntax",
+    expectedMatch: { $0.is(PrimaryAssociatedTypeSyntax.self) },
+    convenienceIsMatch: { $0.isPrimaryAssociatedTypeSyntax },
+    convenienceAsMatch: { $0.asPrimaryAssociatedTypeSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ProtocolDeclSyntax",
+    expectedMatch: { $0.is(ProtocolDeclSyntax.self) },
+    convenienceIsMatch: { $0.isProtocolDeclSyntax },
+    convenienceAsMatch: { $0.asProtocolDeclSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "RegexLiteralExprSyntax",
+    expectedMatch: { $0.is(RegexLiteralExprSyntax.self) },
+    convenienceIsMatch: { $0.isRegexLiteralExprSyntax },
+    convenienceAsMatch: { $0.asRegexLiteralExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "RepeatStmtSyntax",
+    expectedMatch: { $0.is(RepeatStmtSyntax.self) },
+    convenienceIsMatch: { $0.isRepeatStmtSyntax },
+    convenienceAsMatch: { $0.asRepeatStmtSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ReturnClauseSyntax",
+    expectedMatch: { $0.is(ReturnClauseSyntax.self) },
+    convenienceIsMatch: { $0.isReturnClauseSyntax },
+    convenienceAsMatch: { $0.asReturnClauseSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ReturnStmtSyntax",
+    expectedMatch: { $0.is(ReturnStmtSyntax.self) },
+    convenienceIsMatch: { $0.isReturnStmtSyntax },
+    convenienceAsMatch: { $0.asReturnStmtSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "SameTypeRequirementSyntax",
+    expectedMatch: { $0.is(SameTypeRequirementSyntax.self) },
+    convenienceIsMatch: { $0.isSameTypeRequirementSyntax },
+    convenienceAsMatch: { $0.asSameTypeRequirementSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "SequenceExprSyntax",
+    expectedMatch: { $0.is(SequenceExprSyntax.self) },
+    convenienceIsMatch: { $0.isSequenceExprSyntax },
+    convenienceAsMatch: { $0.asSequenceExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "SimpleStringLiteralExprSyntax",
+    expectedMatch: { $0.is(SimpleStringLiteralExprSyntax.self) },
+    convenienceIsMatch: { $0.isSimpleStringLiteralExprSyntax },
+    convenienceAsMatch: { $0.asSimpleStringLiteralExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "SimpleStringLiteralSegmentListSyntax",
+    expectedMatch: { $0.is(SimpleStringLiteralSegmentListSyntax.self) },
+    convenienceIsMatch: { $0.isSimpleStringLiteralSegmentListSyntax },
+    convenienceAsMatch: { $0.asSimpleStringLiteralSegmentListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "SimpleTypeSpecifierSyntax",
+    expectedMatch: { $0.is(SimpleTypeSpecifierSyntax.self) },
+    convenienceIsMatch: { $0.isSimpleTypeSpecifierSyntax },
+    convenienceAsMatch: { $0.asSimpleTypeSpecifierSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "SomeOrAnyTypeSyntax",
+    expectedMatch: { $0.is(SomeOrAnyTypeSyntax.self) },
+    convenienceIsMatch: { $0.isSomeOrAnyTypeSyntax },
+    convenienceAsMatch: { $0.asSomeOrAnyTypeSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "SourceFileSyntax",
+    expectedMatch: { $0.is(SourceFileSyntax.self) },
+    convenienceIsMatch: { $0.isSourceFileSyntax },
+    convenienceAsMatch: { $0.asSourceFileSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "SpecializeAttributeArgumentListSyntax",
+    expectedMatch: { $0.is(SpecializeAttributeArgumentListSyntax.self) },
+    convenienceIsMatch: { $0.isSpecializeAttributeArgumentListSyntax },
+    convenienceAsMatch: { $0.asSpecializeAttributeArgumentListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "SpecializeAvailabilityArgumentSyntax",
+    expectedMatch: { $0.is(SpecializeAvailabilityArgumentSyntax.self) },
+    convenienceIsMatch: { $0.isSpecializeAvailabilityArgumentSyntax },
+    convenienceAsMatch: { $0.asSpecializeAvailabilityArgumentSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "SpecializeTargetFunctionArgumentSyntax",
+    expectedMatch: { $0.is(SpecializeTargetFunctionArgumentSyntax.self) },
+    convenienceIsMatch: { $0.isSpecializeTargetFunctionArgumentSyntax },
+    convenienceAsMatch: { $0.asSpecializeTargetFunctionArgumentSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "StmtSyntax",
+    expectedMatch: { $0.is(StmtSyntax.self) },
+    convenienceIsMatch: { $0.isStmtSyntax },
+    convenienceAsMatch: { $0.asStmtSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "StringLiteralExprSyntax",
+    expectedMatch: { $0.is(StringLiteralExprSyntax.self) },
+    convenienceIsMatch: { $0.isStringLiteralExprSyntax },
+    convenienceAsMatch: { $0.asStringLiteralExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "StringLiteralSegmentListSyntax",
+    expectedMatch: { $0.is(StringLiteralSegmentListSyntax.self) },
+    convenienceIsMatch: { $0.isStringLiteralSegmentListSyntax },
+    convenienceAsMatch: { $0.asStringLiteralSegmentListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "StringSegmentSyntax",
+    expectedMatch: { $0.is(StringSegmentSyntax.self) },
+    convenienceIsMatch: { $0.isStringSegmentSyntax },
+    convenienceAsMatch: { $0.asStringSegmentSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "StructDeclSyntax",
+    expectedMatch: { $0.is(StructDeclSyntax.self) },
+    convenienceIsMatch: { $0.isStructDeclSyntax },
+    convenienceAsMatch: { $0.asStructDeclSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "SubscriptCallExprSyntax",
+    expectedMatch: { $0.is(SubscriptCallExprSyntax.self) },
+    convenienceIsMatch: { $0.isSubscriptCallExprSyntax },
+    convenienceAsMatch: { $0.asSubscriptCallExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "SubscriptDeclSyntax",
+    expectedMatch: { $0.is(SubscriptDeclSyntax.self) },
+    convenienceIsMatch: { $0.isSubscriptDeclSyntax },
+    convenienceAsMatch: { $0.asSubscriptDeclSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "SuperExprSyntax",
+    expectedMatch: { $0.is(SuperExprSyntax.self) },
+    convenienceIsMatch: { $0.isSuperExprSyntax },
+    convenienceAsMatch: { $0.asSuperExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "SuppressedTypeSyntax",
+    expectedMatch: { $0.is(SuppressedTypeSyntax.self) },
+    convenienceIsMatch: { $0.isSuppressedTypeSyntax },
+    convenienceAsMatch: { $0.asSuppressedTypeSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "SwitchCaseItemListSyntax",
+    expectedMatch: { $0.is(SwitchCaseItemListSyntax.self) },
+    convenienceIsMatch: { $0.isSwitchCaseItemListSyntax },
+    convenienceAsMatch: { $0.asSwitchCaseItemListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "SwitchCaseItemSyntax",
+    expectedMatch: { $0.is(SwitchCaseItemSyntax.self) },
+    convenienceIsMatch: { $0.isSwitchCaseItemSyntax },
+    convenienceAsMatch: { $0.asSwitchCaseItemSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "SwitchCaseLabelSyntax",
+    expectedMatch: { $0.is(SwitchCaseLabelSyntax.self) },
+    convenienceIsMatch: { $0.isSwitchCaseLabelSyntax },
+    convenienceAsMatch: { $0.asSwitchCaseLabelSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "SwitchCaseListSyntax",
+    expectedMatch: { $0.is(SwitchCaseListSyntax.self) },
+    convenienceIsMatch: { $0.isSwitchCaseListSyntax },
+    convenienceAsMatch: { $0.asSwitchCaseListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "SwitchCaseSyntax",
+    expectedMatch: { $0.is(SwitchCaseSyntax.self) },
+    convenienceIsMatch: { $0.isSwitchCaseSyntax },
+    convenienceAsMatch: { $0.asSwitchCaseSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "SwitchDefaultLabelSyntax",
+    expectedMatch: { $0.is(SwitchDefaultLabelSyntax.self) },
+    convenienceIsMatch: { $0.isSwitchDefaultLabelSyntax },
+    convenienceAsMatch: { $0.asSwitchDefaultLabelSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "SwitchExprSyntax",
+    expectedMatch: { $0.is(SwitchExprSyntax.self) },
+    convenienceIsMatch: { $0.isSwitchExprSyntax },
+    convenienceAsMatch: { $0.asSwitchExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "TernaryExprSyntax",
+    expectedMatch: { $0.is(TernaryExprSyntax.self) },
+    convenienceIsMatch: { $0.isTernaryExprSyntax },
+    convenienceAsMatch: { $0.asTernaryExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ThrowStmtSyntax",
+    expectedMatch: { $0.is(ThrowStmtSyntax.self) },
+    convenienceIsMatch: { $0.isThrowStmtSyntax },
+    convenienceAsMatch: { $0.asThrowStmtSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ThrowsClauseSyntax",
+    expectedMatch: { $0.is(ThrowsClauseSyntax.self) },
+    convenienceIsMatch: { $0.isThrowsClauseSyntax },
+    convenienceAsMatch: { $0.asThrowsClauseSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "TokenSyntax",
+    expectedMatch: { $0.is(TokenSyntax.self) },
+    convenienceIsMatch: { $0.isTokenSyntax },
+    convenienceAsMatch: { $0.asTokenSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "TryExprSyntax",
+    expectedMatch: { $0.is(TryExprSyntax.self) },
+    convenienceIsMatch: { $0.isTryExprSyntax },
+    convenienceAsMatch: { $0.asTryExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "TupleExprSyntax",
+    expectedMatch: { $0.is(TupleExprSyntax.self) },
+    convenienceIsMatch: { $0.isTupleExprSyntax },
+    convenienceAsMatch: { $0.asTupleExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "TuplePatternElementListSyntax",
+    expectedMatch: { $0.is(TuplePatternElementListSyntax.self) },
+    convenienceIsMatch: { $0.isTuplePatternElementListSyntax },
+    convenienceAsMatch: { $0.asTuplePatternElementListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "TuplePatternElementSyntax",
+    expectedMatch: { $0.is(TuplePatternElementSyntax.self) },
+    convenienceIsMatch: { $0.isTuplePatternElementSyntax },
+    convenienceAsMatch: { $0.asTuplePatternElementSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "TuplePatternSyntax",
+    expectedMatch: { $0.is(TuplePatternSyntax.self) },
+    convenienceIsMatch: { $0.isTuplePatternSyntax },
+    convenienceAsMatch: { $0.asTuplePatternSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "TupleTypeElementListSyntax",
+    expectedMatch: { $0.is(TupleTypeElementListSyntax.self) },
+    convenienceIsMatch: { $0.isTupleTypeElementListSyntax },
+    convenienceAsMatch: { $0.asTupleTypeElementListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "TupleTypeElementSyntax",
+    expectedMatch: { $0.is(TupleTypeElementSyntax.self) },
+    convenienceIsMatch: { $0.isTupleTypeElementSyntax },
+    convenienceAsMatch: { $0.asTupleTypeElementSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "TupleTypeSyntax",
+    expectedMatch: { $0.is(TupleTypeSyntax.self) },
+    convenienceIsMatch: { $0.isTupleTypeSyntax },
+    convenienceAsMatch: { $0.asTupleTypeSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "TypeAliasDeclSyntax",
+    expectedMatch: { $0.is(TypeAliasDeclSyntax.self) },
+    convenienceIsMatch: { $0.isTypeAliasDeclSyntax },
+    convenienceAsMatch: { $0.asTypeAliasDeclSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "TypeAnnotationSyntax",
+    expectedMatch: { $0.is(TypeAnnotationSyntax.self) },
+    convenienceIsMatch: { $0.isTypeAnnotationSyntax },
+    convenienceAsMatch: { $0.asTypeAnnotationSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "TypeEffectSpecifiersSyntax",
+    expectedMatch: { $0.is(TypeEffectSpecifiersSyntax.self) },
+    convenienceIsMatch: { $0.isTypeEffectSpecifiersSyntax },
+    convenienceAsMatch: { $0.asTypeEffectSpecifiersSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "TypeExprSyntax",
+    expectedMatch: { $0.is(TypeExprSyntax.self) },
+    convenienceIsMatch: { $0.isTypeExprSyntax },
+    convenienceAsMatch: { $0.asTypeExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "TypeInitializerClauseSyntax",
+    expectedMatch: { $0.is(TypeInitializerClauseSyntax.self) },
+    convenienceIsMatch: { $0.isTypeInitializerClauseSyntax },
+    convenienceAsMatch: { $0.asTypeInitializerClauseSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "TypeSpecifierListSyntax",
+    expectedMatch: { $0.is(TypeSpecifierListSyntax.self) },
+    convenienceIsMatch: { $0.isTypeSpecifierListSyntax },
+    convenienceAsMatch: { $0.asTypeSpecifierListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "TypeSyntax",
+    expectedMatch: { $0.is(TypeSyntax.self) },
+    convenienceIsMatch: { $0.isTypeSyntax },
+    convenienceAsMatch: { $0.asTypeSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "UnexpectedNodesSyntax",
+    expectedMatch: { $0.is(UnexpectedNodesSyntax.self) },
+    convenienceIsMatch: { $0.isUnexpectedNodesSyntax },
+    convenienceAsMatch: { $0.asUnexpectedNodesSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "UnresolvedAsExprSyntax",
+    expectedMatch: { $0.is(UnresolvedAsExprSyntax.self) },
+    convenienceIsMatch: { $0.isUnresolvedAsExprSyntax },
+    convenienceAsMatch: { $0.asUnresolvedAsExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "UnresolvedIsExprSyntax",
+    expectedMatch: { $0.is(UnresolvedIsExprSyntax.self) },
+    convenienceIsMatch: { $0.isUnresolvedIsExprSyntax },
+    convenienceAsMatch: { $0.asUnresolvedIsExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "UnresolvedTernaryExprSyntax",
+    expectedMatch: { $0.is(UnresolvedTernaryExprSyntax.self) },
+    convenienceIsMatch: { $0.isUnresolvedTernaryExprSyntax },
+    convenienceAsMatch: { $0.asUnresolvedTernaryExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "UnsafeExprSyntax",
+    expectedMatch: { $0.is(UnsafeExprSyntax.self) },
+    convenienceIsMatch: { $0.isUnsafeExprSyntax },
+    convenienceAsMatch: { $0.asUnsafeExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "ValueBindingPatternSyntax",
+    expectedMatch: { $0.is(ValueBindingPatternSyntax.self) },
+    convenienceIsMatch: { $0.isValueBindingPatternSyntax },
+    convenienceAsMatch: { $0.asValueBindingPatternSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "VariableDeclSyntax",
+    expectedMatch: { $0.is(VariableDeclSyntax.self) },
+    convenienceIsMatch: { $0.isVariableDeclSyntax },
+    convenienceAsMatch: { $0.asVariableDeclSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "VersionComponentListSyntax",
+    expectedMatch: { $0.is(VersionComponentListSyntax.self) },
+    convenienceIsMatch: { $0.isVersionComponentListSyntax },
+    convenienceAsMatch: { $0.asVersionComponentListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "VersionComponentSyntax",
+    expectedMatch: { $0.is(VersionComponentSyntax.self) },
+    convenienceIsMatch: { $0.isVersionComponentSyntax },
+    convenienceAsMatch: { $0.asVersionComponentSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "VersionTupleSyntax",
+    expectedMatch: { $0.is(VersionTupleSyntax.self) },
+    convenienceIsMatch: { $0.isVersionTupleSyntax },
+    convenienceAsMatch: { $0.asVersionTupleSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "WhereClauseSyntax",
+    expectedMatch: { $0.is(WhereClauseSyntax.self) },
+    convenienceIsMatch: { $0.isWhereClauseSyntax },
+    convenienceAsMatch: { $0.asWhereClauseSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "WhileStmtSyntax",
+    expectedMatch: { $0.is(WhileStmtSyntax.self) },
+    convenienceIsMatch: { $0.isWhileStmtSyntax },
+    convenienceAsMatch: { $0.asWhileStmtSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "WildcardPatternSyntax",
+    expectedMatch: { $0.is(WildcardPatternSyntax.self) },
+    convenienceIsMatch: { $0.isWildcardPatternSyntax },
+    convenienceAsMatch: { $0.asWildcardPatternSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "YieldStmtSyntax",
+    expectedMatch: { $0.is(YieldStmtSyntax.self) },
+    convenienceIsMatch: { $0.isYieldStmtSyntax },
+    convenienceAsMatch: { $0.asYieldStmtSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "YieldedExpressionListSyntax",
+    expectedMatch: { $0.is(YieldedExpressionListSyntax.self) },
+    convenienceIsMatch: { $0.isYieldedExpressionListSyntax },
+    convenienceAsMatch: { $0.asYieldedExpressionListSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "YieldedExpressionSyntax",
+    expectedMatch: { $0.is(YieldedExpressionSyntax.self) },
+    convenienceIsMatch: { $0.isYieldedExpressionSyntax },
+    convenienceAsMatch: { $0.asYieldedExpressionSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "YieldedExpressionsClauseSyntax",
+    expectedMatch: { $0.is(YieldedExpressionsClauseSyntax.self) },
+    convenienceIsMatch: { $0.isYieldedExpressionsClauseSyntax },
+    convenienceAsMatch: { $0.asYieldedExpressionsClauseSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "_CanImportExprSyntax",
+    expectedMatch: { $0.is(_CanImportExprSyntax.self) },
+    convenienceIsMatch: { $0.isCanImportExprSyntax },
+    convenienceAsMatch: { $0.asCanImportExprSyntax != nil }
+  ),
+  SyntaxCastConvenienceProbe(
+    name: "_CanImportVersionInfoSyntax",
+    expectedMatch: { $0.is(_CanImportVersionInfoSyntax.self) },
+    convenienceIsMatch: { $0.isCanImportVersionInfoSyntax },
+    convenienceAsMatch: { $0.asCanImportVersionInfoSyntax != nil }
+  ),
+]
+
+@Test("Generated syntax-element cast conveniences agree with SwiftSyntax casting")
+func testGeneratedSyntaxElementCastConveniencesAgreeWithSwiftSyntaxCasting() throws {
+  // This property-style test mechanically covers every generated `as*` and `is*`
+  // convenience. The property is that each wrapper must agree with SwiftSyntax's
+  // generic casting API for several representative syntax trees, which is broader
+  // than the hand-written representative example in `SyntaxProtocolConvenience+Tests`.
+  for sample in try syntaxCastSamples() {
+    for probe in syntaxCastConvenienceProbes {
+      let expected = probe.expectedMatch(sample.syntax)
+
+      #expect(probe.convenienceIsMatch(sample.syntax) == expected)
+      #expect(probe.convenienceAsMatch(sample.syntax) == expected)
+    }
+  }
+}
+
+private func syntaxCastSamples() throws -> [SyntaxCastSample] {
+  let source = """
+  @available(macOS 14.0, *)
+  public struct Widget<T>: Sendable where T: Sequence {
+    public var count: Int = 0
+
+    public func value(_ input: T) async throws -> Int {
+      guard true else { return 0 }
+      return count
+    }
+  }
+
+  enum Choice {
+    case one(Int)
+    case two
+  }
+
+  let tuple: (Int, String) = (1, "value")
+  _ = tuple.0
+  """
+
+  let sourceFile = try SourceFileSyntax.onlyParsed(from: source)
+
+  return [
+    SyntaxCastSample(name: "source file", syntax: Syntax(sourceFile)),
+    SyntaxCastSample(name: "struct declaration", syntax: Syntax(try StructDeclSyntax.firstParsed(from: source))),
+    SyntaxCastSample(name: "enum declaration", syntax: Syntax(try EnumDeclSyntax.firstParsed(from: source))),
+    SyntaxCastSample(name: "function declaration", syntax: Syntax(try FunctionDeclSyntax.firstParsed(from: source))),
+    SyntaxCastSample(name: "stored property", syntax: Syntax(try VariableDeclSyntax.firstParsed(from: source))),
+    SyntaxCastSample(name: "identifier type", syntax: Syntax(try IdentifierTypeSyntax.firstParsed(from: source))),
+    SyntaxCastSample(name: "boolean literal", syntax: Syntax(try BooleanLiteralExprSyntax.firstParsed(from: source))),
+    SyntaxCastSample(name: "return statement", syntax: Syntax(try ReturnStmtSyntax.firstParsed(from: source))),
+    SyntaxCastSample(name: "tuple expression", syntax: Syntax(try TupleExprSyntax.firstParsed(from: source))),
+    SyntaxCastSample(name: "member access", syntax: Syntax(try MemberAccessExprSyntax.firstParsed(from: source))),
+    SyntaxCastSample(name: "token", syntax: Syntax(TokenSyntax.identifier("Widget"))),
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds new `SyntaxProtocol` helpers: element-cast accessors, tree-search utilities, and source-parsing convenience APIs.
- Broadens `eraseTo*Syntax` coverage from `DeclSyntaxProtocol` to also include `SyntaxProtocol`, `ExprSyntaxProtocol`, and `PatternSyntaxProtocol`, and refactors `String` tuple-stringification through shared component helpers.
- Changes the diagnostic-builder return type from `DiagnosticsError` to `Diagnostic` so callers can compose multiple diagnostics, with small introspection/macro-protocol cleanups in support.
- Lands large new test suites covering diagnostics, generation, introspection, macro-protocol, model, and support layers (~10k LOC).

## Test plan

- [ ] `swift test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)